### PR TITLE
Vulkan backend fixes for Linux

### DIFF
--- a/shaders/lighting.frag
+++ b/shaders/lighting.frag
@@ -15,8 +15,6 @@ layout(constant_id = 2) const int LightTypeDir = 2;
 // viable ights in the storage buffer.
 layout(constant_id = 3) const int BufferEndSignal = 255;
 
-layout(constant_id = 4) const int MaxLightCount = 250;
-
 void main()
 {
     vec3 inPos = texture(PositionSampler, inUv).rgb;
@@ -56,7 +54,7 @@ void main()
     // apply additional lighting contribution to specular
     vec3 colour = baseColour;
 
-    for (int idx = 0; idx < MaxLightCount; idx++)
+    for (int idx = 0; idx < 2000; idx++)
     {
         LightParams params = light_ssbo.params[idx];
         if (params.lightType == BufferEndSignal)

--- a/yave/src/skybox.cpp
+++ b/yave/src/skybox.cpp
@@ -61,15 +61,15 @@ ISkybox::ISkybox(IEngine& engine)
 void ISkybox::buildI(ICamera& cam)
 {
     // cube vertices
-    const std::array<mathfu::vec3, 8> vertices {
-        mathfu::vec3 {-1.0f, -1.0f, 1.0f},
-        mathfu::vec3 {1.0f, -1.0f, 1.0f},
-        mathfu::vec3 {1.0f, 1.0f, 1.0f},
-        mathfu::vec3 {-1.0f, 1.0f, 1.0f},
-        mathfu::vec3 {-1.0f, -1.0f, -1.0f},
-        mathfu::vec3 {1.0f, -1.0f, -1.0f},
-        mathfu::vec3 {1.0f, 1.0f, -1.0f},
-        mathfu::vec3 {-1.0f, 1.0f, -1.0f}};
+    const std::array<float, 24> vertices {
+        -1.0f, -1.0f, 1.0f,
+        1.0f, -1.0f, 1.0f,
+        1.0f, 1.0f, 1.0f,
+        -1.0f, 1.0f, 1.0f,
+        -1.0f, -1.0f, -1.0f,
+        1.0f, -1.0f, -1.0f,
+        1.0f, 1.0f, -1.0f,
+        -1.0f, 1.0f, -1.0f};
 
     // cube indices
     // clang-format off
@@ -109,7 +109,7 @@ void ISkybox::buildI(ICamera& cam)
     vBuffer->addAttribute(
         VertexBuffer::BindingType::Position,
         backend::BufferElementType::Float3);
-    vBuffer->buildI(driver, vertices.size() * sizeof(mathfu::vec3), (void*)vertices.data());
+    vBuffer->buildI(driver, vertices.size() * sizeof(float), (void*)vertices.data());
     iBuffer->buildI(
         driver, indices.size(), (void*)indices.data(), backend::IndexBufferType::Uint32);
     prim->addMeshDrawDataI(indices.size(), 0);


### PR DESCRIPTION
- Unable to use specilaisation constants for `for` loops withing glsl shader code on Intel (and NVidia?) so setting to a constant max value for light count.
- An array of mathfu::vec3 for the skybox vertices was being copied incorrectly. Changed to an array of floats.