### PR TITLE
Add wave generator part one 

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -41,8 +41,10 @@ endfunction()
 create_app(APP_NAME primitives FILES primitives.cpp primitives.h)
 create_app(APP_NAME gltf_model FILES gltf_model.cpp gltf_model.h)
 create_app(APP_NAME triangle FILES triangle.cpp)
+create_app(APP_NAME wave_demo FILES wave_demo.cpp wave_demo.h)
 
 target_link_libraries(primitives PUBLIC mathfu::mathfu YaveUtility)
 target_link_libraries(gltf_model PUBLIC mathfu::mathfu YaveUtility YaveIbl)
 target_link_libraries(triangle PUBLIC mathfu::mathfu)
+target_link_libraries(wave_demo PUBLIC mathfu::mathfu YaveUtility YaveIbl YaveImageUtils)
 

--- a/apps/wave_demo.cpp
+++ b/apps/wave_demo.cpp
@@ -47,7 +47,7 @@
 #include <memory>
 
 void WaveApp::uiCallback(yave::Engine* engine) {}
- 
+
 int main()
 {
     yave::AppParams params {"wave demo", 1920, 1080};

--- a/apps/wave_demo.cpp
+++ b/apps/wave_demo.cpp
@@ -1,0 +1,93 @@
+
+/* Copyright (c) 2022 Garry Whitehead
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "wave_demo.h"
+
+#include "backend/convert_to_vk.h"
+#include "backend/convert_to_yave.h"
+#include "backend/enums.h"
+#include "yave/camera.h"
+#include "yave/index_buffer.h"
+#include "yave/indirect_light.h"
+#include "yave/object_manager.h"
+#include "yave/render_primitive.h"
+#include "yave/renderable.h"
+#include "yave/renderable_manager.h"
+#include "yave/skybox.h"
+#include "yave/texture.h"
+#include "yave/texture_sampler.h"
+#include "yave/vertex_buffer.h"
+#include "yave/wave_generator.h"
+
+#include <ibl/ibl.h>
+#include <imgui.h>
+#include <utility/colour.h>
+#include <yave_app/app.h>
+
+#include <memory>
+
+void WaveApp::uiCallback(yave::Engine* engine) {}
+ 
+int main()
+{
+    yave::AppParams params {"wave demo", 1920, 1080};
+    WaveApp app(params, true);
+
+    app.engine_ = app.getEngine();
+    app.scene_ = app.getScene();
+
+    // create irradiance/specular maps
+    yave::Ibl ibl(app.engine_, YAVE_ASSETS_DIRECTORY);
+    if (!ibl.loadEqirectImage("hdr/monoLake.hdr"))
+    {
+        exit(1);
+    }
+    yave::IndirectLight* il = app.engine_->createIndirectLight();
+    il->setIrrandianceMap(ibl.getIrradianceMap());
+    il->setSpecularMap(ibl.getSpecularMap(), ibl.getBrdfLut());
+    app.scene_->setIndirectLight(il);
+
+    yave::AssetLoader loader(app.engine_);
+    loader.setAssetFolder(YAVE_ASSETS_DIRECTORY);
+
+    // add the skybox to the scene
+    yave::Skybox* skybox = app.engine_->createSkybox(app.scene_);
+    skybox->setTexture(ibl.getCubeMap());
+    skybox->build(app.scene_, app.getWindow()->getCamera());
+    app.scene_->setSkybox(skybox);
+
+    // add some waves....
+    yave::WaveGenerator* waveGen = app.engine_->createWaveGenerator();
+    app.scene_->setWaveGenerator(waveGen);
+
+    // create the renderer used to draw to the backbuffer
+    auto handle = app.engine_->createSwapchain(app.getWindow());
+    app.engine_->setCurrentSwapchain(handle);
+    auto renderer = app.engine_->createRenderer();
+
+    app.run(renderer, app.scene_);
+
+    yave::Engine::destroy(app.engine_);
+
+    exit(0);
+}

--- a/apps/wave_demo.h
+++ b/apps/wave_demo.h
@@ -36,7 +36,6 @@
 class WaveApp : public yave::Application
 {
 public:
-
     WaveApp(const yave::AppParams& params, bool showUI) : yave::Application(params, showUI) {}
 
     void uiCallback(yave::Engine* engine) override;

--- a/apps/wave_demo.h
+++ b/apps/wave_demo.h
@@ -19,49 +19,33 @@
  * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
+
 #pragma once
 
-#include "options.h"
+#include "yave/engine.h"
+#include "yave/light_manager.h"
+#include "yave/material.h"
+#include "yave/object.h"
+#include "yave/scene.h"
+#include "yave/transform_manager.h"
+#include "yave_app/app.h"
 
-#include <memory>
+#include <model_parser/gltf/gltf_model.h>
+#include <yave_app/asset_loader.h>
 
-namespace yave
-{
-class Skybox;
-class Camera;
-class Object;
-class IndirectLight;
-class WaveGenerator;
-
-class Scene
+class WaveApp : public yave::Application
 {
 public:
-    virtual ~Scene();
 
-    virtual void setSkybox(Skybox* skybox) = 0;
+    WaveApp(const yave::AppParams& params, bool showUI) : yave::Application(params, showUI) {}
 
-    virtual void setIndirectLight(IndirectLight* il) = 0;
+    void uiCallback(yave::Engine* engine) override;
 
-    virtual void setCamera(Camera* camera) = 0;
+    yave::Scene* scene_ = nullptr;
+    yave::Engine* engine_ = nullptr;
 
-    virtual void setWaveGenerator(WaveGenerator* waterGen) = 0;
+    yave::Object dirLightObj;
+    yave::Object spotLightObj;
 
-    virtual Camera* getCurrentCamera() = 0;
-
-    virtual void addObject(Object obj) = 0;
-    virtual void destroyObject(Object obj) = 0;
-
-    virtual void usePostProcessing(bool state) = 0;
-
-    virtual void useGbuffer(bool state) = 0;
-
-    virtual void setBloomOptions(const BloomOptions& bloom) = 0;
-    virtual void setGbufferOptions(const GbufferOptions& gb) = 0;
-    virtual BloomOptions& getBloomOptions() = 0;
-    virtual GbufferOptions& getGbufferOptions() = 0;
-
-protected:
-    Scene();
+    std::vector<yave::Material*> materials;
 };
-
-} // namespace yave

--- a/libs/image_utils/noise_generator.cpp
+++ b/libs/image_utils/noise_generator.cpp
@@ -20,17 +20,19 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+
 #include "noise_generator.h"
 
 #include <utility/colour.h>
 
+#include <algorithm>
 #include <cstdlib>
-#include <random>
 #include <numeric>
+#include <random>
 
 namespace yave
 {
-NoiseGenerator::NoiseGenerator(uint32_t seed) 
+NoiseGenerator::NoiseGenerator(uint32_t seed)
 {
     permutations_.resize(256);
     std::iota(permutations_.begin(), permutations_.end(), 0);
@@ -43,7 +45,7 @@ NoiseGenerator::NoiseGenerator(uint32_t seed)
     permutations_.insert(permutations_.end(), permutations_.begin(), permutations_.end());
 }
 
-NoiseGenerator::~NoiseGenerator() { }
+NoiseGenerator::~NoiseGenerator() {}
 
 double NoiseGenerator::fade(double t) { return t * t * t * (t * (t * 6 - 15) + 10); }
 
@@ -62,7 +64,7 @@ double NoiseGenerator::generateNoise(double x, double y, double z)
     int X = (int)floor(x) & 255;
     int Y = (int)floor(y) & 255;
     int Z = (int)floor(z) & 255;
-    
+
     x -= floor(x);
     y -= floor(y);
     z -= floor(z);
@@ -100,7 +102,6 @@ double NoiseGenerator::generateNoise(double x, double y, double z)
                 grad(permutations_[BB + 1], x - 1, y - 1, z - 1))));
     return (res + 1.0) / 2.0;
 }
-
 
 
 } // namespace yave

--- a/libs/image_utils/noise_generator.h
+++ b/libs/image_utils/noise_generator.h
@@ -39,10 +39,8 @@ public:
     double generateNoise(double x, double y, double z);
 
     template <typename TYPE>
-    TYPE* generateImage(
-        uint32_t imageWidth, uint32_t imageHeight, uint32_t channels)
+    TYPE* generateImage(uint32_t imageWidth, uint32_t imageHeight, uint32_t channels)
     {
-        
         ASSERT_FATAL(
             channels > 0 && channels <= 4, "Only r, rg or rgb channels supported for image gen.");
         TYPE* imageBuffer = new TYPE[imageWidth * imageHeight * channels];
@@ -71,7 +69,6 @@ public:
     }
 
 private:
-
     double fade(double t);
 
     double lerp(double t, double a, double b);
@@ -79,7 +76,6 @@ private:
     double grad(int hash, double x, double y, double z);
 
 private:
-
     std::vector<int> permutations_;
 };
 

--- a/libs/utility/timer.h
+++ b/libs/utility/timer.h
@@ -68,7 +68,7 @@ public:
         current = timeNow;
     }
 
-    TimeType getTimeElapsed()
+    TimeType getTimeElapsed() 
     {
         auto timeNow =
             std::chrono::duration_cast<TimeType>(std::chrono::high_resolution_clock::now());
@@ -77,7 +77,7 @@ public:
         return deltaTime;
     }
 
-    static TimeType getCurrentTime()
+    static TimeType getCurrentTime() 
     {
         auto timeNow = std::chrono::high_resolution_clock::now();
         return std::chrono::duration_cast<TimeType>(timeNow.time_since_epoch());

--- a/libs/utility/timer.h
+++ b/libs/utility/timer.h
@@ -68,7 +68,7 @@ public:
         current = timeNow;
     }
 
-    TimeType getTimeElapsed() 
+    TimeType getTimeElapsed()
     {
         auto timeNow =
             std::chrono::duration_cast<TimeType>(std::chrono::high_resolution_clock::now());
@@ -77,7 +77,7 @@ public:
         return deltaTime;
     }
 
-    static TimeType getCurrentTime() 
+    static TimeType getCurrentTime()
     {
         auto timeNow = std::chrono::high_resolution_clock::now();
         return std::chrono::duration_cast<TimeType>(timeNow.time_since_epoch());

--- a/libs/yave_app/app.cpp
+++ b/libs/yave_app/app.cpp
@@ -59,7 +59,7 @@ bool Application::run(Renderer* renderer, Scene* scene)
     while (!closeApp_)
     {
         NanoSeconds startTime = timer.getCurrentTime();
-        
+
         // check for any input from the window
         window_->poll();
 

--- a/libs/yave_app/app.cpp
+++ b/libs/yave_app/app.cpp
@@ -59,7 +59,7 @@ bool Application::run(Renderer* renderer, Scene* scene)
     while (!closeApp_)
     {
         NanoSeconds startTime = timer.getCurrentTime();
-
+        
         // check for any input from the window
         window_->poll();
 
@@ -100,11 +100,11 @@ bool Application::run(Renderer* renderer, Scene* scene)
         this->preRenderCallback();
 
         // begin the rendering for this frame - render the main scene
-        renderer->render(engine_, scene, timeStep);
+        renderer->render(engine_, scene, timeStep, timer);
         // and render the UI over this
         if (showUI_)
         {
-            renderer->render(engine_, imgui_->getScene(), timeStep, false);
+            renderer->render(engine_, imgui_->getScene(), timeStep, timer, false);
         }
 
         // user defined post-render callback to be added here

--- a/shaders/fft_butterfly.comp
+++ b/shaders/fft_butterfly.comp
@@ -1,0 +1,56 @@
+
+#include "include/complex.h"
+
+#define PI 3.1415926535897932384626433832795
+
+layout (local_size_x = 1, local_size_y = 16) in;
+
+void main()
+{
+	ivec2 id = ivec2(gl_GlobalInvocationID.xy);
+	if(id.x >= compute_ubo.log2N || id.y >= compute_ubo.N)
+    {
+		return;
+    }
+
+	float k = mod(id.y * (compute_ubo.N /  pow(2, id.x + 1)), compute_ubo.N);
+	
+	complex twiddle = complex(cos(2.0 * PI * k / compute_ubo.N), sin(2.0 * PI * k / compute_ubo.N));
+	int span = int(pow(2, id.x));
+	
+	uint currWing = 0;
+	if (mod(id.y, pow(2, id.x + 1)) < pow(2, id.x))
+    {
+		currWing = 1;
+    }
+
+	if(id.x == 0) 
+    {						
+		// if the first stage, store the indices
+        // top wing
+        if(currWing == 1) 
+        {			
+			// store the twiddle factors and bit reversed indices 
+			imageStore(ButterflyImage, id, vec4(twiddle.r, twiddle.i, ssbo.bitReversed[id.y], ssbo.bitReversed[id.y + 1])); 
+		}
+		else 
+        {							
+            // bottom wing
+			imageStore(ButterflyImage, id, vec4(twiddle.r, twiddle.i, ssbo.bitReversed[id.y - 1], ssbo.bitReversed[id.y])); 
+		}
+	}
+	else 
+    {								
+        // otherwise, store the butterfly span
+        // top wing
+		if(currWing == 1) 
+        {			
+			imageStore(ButterflyImage, id, vec4(twiddle.r, twiddle.i, id.y, id.y + span)); 
+		}
+		else 
+        {							
+            // bottom wing
+			imageStore(ButterflyImage, id, vec4(twiddle.r, twiddle.i, id.y - span, id.y)); 
+		}
+	}
+}

--- a/shaders/fft_displacement.comp
+++ b/shaders/fft_displacement.comp
@@ -1,0 +1,28 @@
+
+
+layout (local_size_x = 16, local_size_y = 16) in;
+
+void main()
+{
+	ivec2 id = ivec2(gl_GlobalInvocationID.xy);
+	if(id.x >= compute_ubo.N || id.y >= compute_ubo.N)
+	{
+		return;
+	}
+
+	uint res = ((id.x + id.y) & 1);
+	float signCorrect = (res == 0) ? 1.0 : -1.0;
+
+	float N2 = compute_ubo.N * compute_ubo.N;
+
+	uint index = id.y * uint(compute_ubo.N) + id.x;
+	
+	float height = (ssbo.out_dxyz[index + compute_ubo.offset_dy].x / N2) * signCorrect;
+	imageStore(HeightMap, id, vec4(height, 0.0, 0.0, 1.0));
+
+	vec2 displace;
+	displace.x = (ssbo.out_dxyz[index + compute_ubo.offset_dx].x / N2) * signCorrect * compute_ubo.choppyFactor;	// use the real number from the fft compute
+	displace.y = (ssbo.out_dxyz[index + compute_ubo.offset_dz].x / N2) * signCorrect * compute_ubo.choppyFactor;
+	
+	imageStore(DisplacementMap, id, vec4(displace, 0.0, 1.0));
+}

--- a/shaders/fft_horiz.comp
+++ b/shaders/fft_horiz.comp
@@ -1,0 +1,54 @@
+
+#include "include/complex.h"
+
+void processButterfly(ivec2 id, vec4 data)
+{
+	complex H;
+	vec2 p0;
+	vec2 q0;
+		
+	uint index_p0 = uint(id.y * compute_ubo.N + data.z);
+	uint index_q0 = uint(id.y * compute_ubo.N + data.w);
+	
+	if (push_params.pingpong == 0)
+	{
+		p0 = ssbo_a.pingpong0[index_p0 + push_params.offset];
+		q0 = ssbo_a.pingpong0[index_q0 + push_params.offset];
+	}
+	else
+	{
+		p0 = ssbo_b.out_dxyz[index_p0 + push_params.offset];
+		q0 = ssbo_b.out_dxyz[index_q0 + push_params.offset];
+	}
+
+	complex p = complex(p0.x, p0.y);
+	complex q = complex(q0.x, q0.y);
+	complex w = complex(data.x, data.y);
+		
+	H = cadd(p, cmul(w, q));
+	
+	uint out_index = id.y * uint(compute_ubo.N) + id.x;
+
+	if (push_params.pingpong == 0)
+	{
+		ssbo_b.out_dxyz[out_index + push_params.offset] = vec2(H.r, H.i);
+	}
+	else
+	{
+		ssbo_a.pingpong0[out_index + push_params.offset] = vec2(H.r, H.i);
+	}
+}
+
+layout (local_size_x = 16, local_size_y = 16) in;
+
+void main()
+{
+	ivec2 id = ivec2(gl_GlobalInvocationID.xy);
+	if(id.y >= compute_ubo.N || id.x >= compute_ubo.N)
+	{
+		return;
+	}
+
+	vec4 data = imageLoad(ButterflySampler, ivec2(push_params.stage, id.x));
+	processButterfly(id, data);
+}

--- a/shaders/fft_spectrum.comp
+++ b/shaders/fft_spectrum.comp
@@ -1,0 +1,55 @@
+
+#include "include/complex.h"
+
+#define PI 3.1415926535897932384626433832795
+#define GRAVITY 9.81
+
+layout (local_size_x = 16, local_size_y = 16) in;
+
+void main()
+{
+	ivec2 id = ivec2(gl_GlobalInvocationID.xy);
+	if(id.y >= compute_ubo.N || id.x >= compute_ubo.N)
+	{
+		return;
+	}
+	
+	vec2 h0_k = imageLoad(H0kImage, id).rg;
+	vec2 h0minus_k = imageLoad(H0minuskImage, id).rg;
+
+	vec2 x = vec2(gl_GlobalInvocationID.xy) - compute_ubo.N / 2.0;
+	vec2 k = vec2(2.0 * PI * x.x / compute_ubo.L, 2.0 * PI * x.y / compute_ubo.L);
+
+	float mag = length(k);
+	if(mag < 0.000001)
+	{
+		mag = 0.000001;
+	}
+
+	float w = sqrt(GRAVITY * mag);
+	
+	complex fft = complex(h0_k.x, h0_k.y);
+	complex fft_conj = conjugate(complex(h0minus_k.x, h0minus_k.y));
+	
+	float cos_omega = cos(w * compute_ubo.time);
+	float sin_omega = sin(w * compute_ubo.time);
+	
+	complex exp_omega = complex(cos_omega, sin_omega);
+	complex inv_exp_omega = complex(cos_omega, -sin_omega);
+
+	// calculate dt(y) height
+	complex dyt = cadd(cmul(fft, exp_omega), cmul(fft_conj, inv_exp_omega));
+	
+	// dt(x) displacement
+	complex dxt = cmul(complex(0.0, -k.x / mag), dyt);		// choppiness of the wave
+	
+	// dt(z) normal
+	complex dzt = cmul(complex(0.0, -k.y / mag), dyt);
+	
+	int index =  id.y * compute_ubo.N + id.x;
+
+	ssbo.out_dxyz[index + compute_ubo.offset_dx] = vec2(dxt.r, dxt.i);
+	ssbo.out_dxyz[index + compute_ubo.offset_dy] = vec2(dyt.r, dyt.i);
+	ssbo.out_dxyz[index + compute_ubo.offset_dz] = vec2(dzt.r, dzt.i);
+}	
+	

--- a/shaders/fft_vert.comp
+++ b/shaders/fft_vert.comp
@@ -1,0 +1,54 @@
+
+#include "include/complex.h"
+
+void processButterfly(ivec2 id, vec4 data)
+{
+	complex H;
+	vec2 p0;
+	vec2 q0;
+	
+	uint index_p0 = uint(data.z * compute_ubo.N + id.x);
+	uint index_q0 = uint(data.w * compute_ubo.N + id.x);
+	
+    if (push_params.pingpong == 0)
+	{
+	    p0 = ssbo_a.pingpong0[index_p0 + push_params.offset];
+	    q0 = ssbo_a.pingpong0[index_q0 + push_params.offset];
+    }
+    else
+    {
+	    p0 = ssbo_b.out_dxyz[index_p0 + push_params.offset];
+	    q0 = ssbo_b.out_dxyz[index_q0 + push_params.offset];
+    }
+
+	complex p = complex(p0.x, p0.y);
+	complex q = complex(q0.x, q0.y);
+	complex w = complex(data.x, data.y);
+		
+	H = cadd(p, cmul(w, q));
+	
+	uint out_index = id.y * uint(compute_ubo.N) + id.x;
+
+	if (push_params.pingpong == 0)
+	{
+		ssbo_b.out_dxyz[out_index + push_params.offset] = vec2(H.r, H.i);
+	}
+	else
+	{
+		ssbo_a.pingpong0[out_index + push_params.offset] = vec2(H.r, H.i);
+	}
+}
+
+layout (local_size_x = 16, local_size_y = 16) in;
+
+void main()
+{
+	ivec2 id = ivec2(gl_GlobalInvocationID.xy);
+	if(id.y >= compute_ubo.N || id.x >= compute_ubo.N)
+	{
+		return;
+	}
+
+	vec4 data = imageLoad(ButterflySampler, ivec2(push_params.stage, id.y));
+	processButterfly(id, data);
+}

--- a/shaders/generate_maps.comp
+++ b/shaders/generate_maps.comp
@@ -1,0 +1,27 @@
+
+layout (local_Size_x = 16, local_size_y = 16) in;
+
+void main()
+{
+	ivec2 id = ivec2(gl_GlobalInvocationID.xy);
+	vec2 uv = vec2(id) / compute_ubo.N;
+	
+	float x0 = textureOffset(HeightMap, uv, ivec2(-1, 0)).r;
+	float x1 = textureOffset(HeightMap, uv, ivec2(1, 0)).r;
+	float y0 = textureOffset(HeightMap, uv, ivec2(0, -1)).r;
+	float y1 = textureOffset(HeightMap, uv, ivec2(0, 1)).r;
+	
+	vec2 grad = vec2(x1 - x0, y1 - y0);
+	
+	float height = texture(HeightMap, uv).r;
+	vec2 displacement = texture(fftOutputImage, uv).rg;
+
+	// calculate Jacobian correlation and store in w component of output vec
+	vec2 dx = (textureOffset(fftOutputImage, uv, ivec2(1, 0)).xy - textureOffset(fftOutputImage, uv, ivec2(-1, 0)).xy) * compute_ubo.choppyFactor * compute_ubo.gridLength;
+	vec2 dy = (textureOffset(fftOutputImage, uv, ivec2(0, 1)).xy - textureOffset(fftOutputImage, uv, ivec2(0, -1)).xy) * compute_ubo.choppyFactor * compute_ubo.gridLength;
+		
+	float j = (1.0 + dx.x) * (1.0 + dy.y) - dx.y * dy.x;
+	
+	imageStore(DisplacementMap, id, vec4(height, displacement, 0.0));
+	imageStore(GradientMap, id, vec4(grad, j, 0.0));
+}

--- a/shaders/include/complex.h
+++ b/shaders/include/complex.h
@@ -1,0 +1,33 @@
+#ifndef COMPLEX_H
+#define COMPLEX_H
+
+struct complex
+{
+    float r;
+    float i;
+};
+
+complex cmul(complex c0, complex c1)
+{
+    complex c;
+    c.r = c0.r * c1.r - c0.i * c1.i;
+    c.i = c0.r * c1.i + c0.i * c1.r;
+    return c;
+}
+
+complex cadd(complex c0, complex c1)
+{
+    complex c;
+    c.r = c0.r + c1.r;
+    c.i = c0.i + c1.i;
+    return c;
+}
+
+complex conjugate(complex c0)
+{
+    complex conj = complex(c0.r, -c0.i);
+    return conj;
+}
+
+
+#endif // COMPLEX_H

--- a/shaders/include/random.h
+++ b/shaders/include/random.h
@@ -1,0 +1,33 @@
+#ifndef RANDOM_H
+#define RANDOM_H
+
+#define PI 3.1415926535897932384626433832795
+
+float rand(vec2 co)
+{
+    // From: http://stackoverflow.com/questions/4200224/random-noise-functions-for-glsl
+    // Produces approximately uniformly distributed values in the interval [0,1].
+    float r = fract(sin(dot(co.xy, vec2(12.9898, 78.233))) * 43758.5453);
+
+    if (r == 0.0)
+    {
+        r = 0.000000000001;
+    }
+    return r;
+}
+
+
+vec2 gaussrand(vec2 co, vec2 offsets)
+{
+    // Box-Muller method for sampling from the normal distribution
+    // http://en.wikipedia.org/wiki/Normal_distribution#Generating_values_from_normal_distribution
+
+    // offsets are applied here otherwise we will end up with the same random numbers
+    // ('rand' is not that random, more of a hash function.)
+    float U = rand(co + vec2(offsets.x, offsets.x));
+    float V = rand(co + vec2(offsets.y, offsets.y));
+
+    return vec2(sqrt(-2.0 * log(U)) * sin(2.0 * PI * V), sqrt(-2.0 * log(U)) * cos(2.0 * PI * V));
+}
+
+#endif

--- a/shaders/initial_spectrum.comp
+++ b/shaders/initial_spectrum.comp
@@ -1,0 +1,50 @@
+
+#define PI 3.1415926535897932384626433832795
+
+const float GRAVITY = 9.81;
+
+layout (local_size_x = 16, local_size_y = 16) in;
+
+float phillips(vec2 k, float max_l)
+{
+    float len = (compute_ubo.windSpeed * compute_ubo.windSpeed) / GRAVITY;
+    float mag = length(k);
+    if (mag == 0.0)
+    {
+        return mag;
+    }
+
+    float mag2 = mag * mag;
+    float kdotw = dot(normalize(k), normalize(compute_ubo.windDirection));
+
+    return (kdotw * kdotw) *       
+        exp(-1.0 * mag2 * max_l * max_l) * 
+        exp(-1.0f / (mag2 * len * len)) *
+        pow(mag, -4.0f);
+}
+
+void main()
+{   
+    ivec2 id = ivec2(gl_GlobalInvocationID.xy);
+	if(id.y >= compute_ubo.N || id.x >= compute_ubo.N)
+    {
+		return;
+    }
+ 
+    vec2 x = vec2(gl_GlobalInvocationID.xy) - compute_ubo.N / 2.0;
+    vec2 k = vec2(2.0 * PI * x.x / float(compute_ubo.L), 2.0 * PI * x.y / float(compute_ubo.L));
+
+    // calculate the phillips spectrum
+    float max_l = 0.02;
+    float ph = compute_ubo.A * phillips(k, max_l);
+
+    float phminusk = compute_ubo.A * phillips(-k, max_l);
+  
+    vec4 gaussRnd = imageLoad(NoiseImage, id).xyzw;
+ 
+    vec2 h0 = gaussRnd.xy * (sqrt(ph) * 0.5);
+    vec2 h0minusk = gaussRnd.zw * (sqrt(phminusk) * 0.5);
+
+    imageStore(H0kImage, id, vec4(h0, 0.0, 1.0));
+    imageStore(H0minuskImage, id, vec4(h0minusk, 0.0, 1.0));
+}

--- a/vulkan-api/src/backend/convert_to_vk.cpp
+++ b/vulkan-api/src/backend/convert_to_vk.cpp
@@ -280,6 +280,9 @@ vk::Format textureFormatToVk(backend::TextureFormat type)
         case backend::TextureFormat::R32F:
             output = vk::Format::eR32Sfloat;
             break;
+        case backend::TextureFormat::R32U:
+            output = vk::Format::eR32Uint;
+            break;
         case backend::TextureFormat::RG8:
             output = vk::Format::eR8G8Unorm;
             break;

--- a/vulkan-api/src/backend/enums.h
+++ b/vulkan-api/src/backend/enums.h
@@ -147,6 +147,7 @@ enum class TextureFormat
     R8,
     R16F,
     R32F,
+    R32U,
     RG8,
     RG16F,
     RG32F,

--- a/vulkan-api/src/vulkan-api/context.cpp
+++ b/vulkan-api/src/vulkan-api/context.cpp
@@ -523,14 +523,14 @@ void VkContext::GlobalBarrier(
     vk::PipelineStageFlags dstStage,
     vk::AccessFlags srcAccess,
     vk::AccessFlags dstAccess)
-{ 
-    vk::MemoryBarrier barrier {srcAccess, dstAccess}; 
+{
+    vk::MemoryBarrier barrier {srcAccess, dstAccess};
     cmds.pipelineBarrier(
         srcStage, dstStage, (vk::DependencyFlags)0, 1, &barrier, 0, nullptr, 0, nullptr);
 }
 
-void VkContext::writeReadComputeBarrier(vk::CommandBuffer& cmds) 
-{ 
+void VkContext::writeReadComputeBarrier(vk::CommandBuffer& cmds)
+{
     GlobalBarrier(
         cmds,
         vk::PipelineStageFlagBits::eComputeShader,
@@ -540,9 +540,7 @@ void VkContext::writeReadComputeBarrier(vk::CommandBuffer& cmds)
 }
 
 void VkContext::ExecutionBarrier(
-    vk::CommandBuffer& cmds,
-    vk::PipelineStageFlags srcStage,
-    vk::PipelineStageFlags dstStage)
+    vk::CommandBuffer& cmds, vk::PipelineStageFlags srcStage, vk::PipelineStageFlags dstStage)
 {
     cmds.pipelineBarrier(
         srcStage, dstStage, (vk::DependencyFlags)0, 0, nullptr, 0, nullptr, 0, nullptr);

--- a/vulkan-api/src/vulkan-api/context.cpp
+++ b/vulkan-api/src/vulkan-api/context.cpp
@@ -517,4 +517,35 @@ uint32_t VkContext::selectMemoryType(uint32_t flags, vk::MemoryPropertyFlags req
     return UINT32_MAX;
 }
 
+void VkContext::GlobalBarrier(
+    vk::CommandBuffer& cmds,
+    vk::PipelineStageFlags srcStage,
+    vk::PipelineStageFlags dstStage,
+    vk::AccessFlags srcAccess,
+    vk::AccessFlags dstAccess)
+{ 
+    vk::MemoryBarrier barrier {srcAccess, dstAccess}; 
+    cmds.pipelineBarrier(
+        srcStage, dstStage, (vk::DependencyFlags)0, 1, &barrier, 0, nullptr, 0, nullptr);
+}
+
+void VkContext::writeReadComputeBarrier(vk::CommandBuffer& cmds) 
+{ 
+    GlobalBarrier(
+        cmds,
+        vk::PipelineStageFlagBits::eComputeShader,
+        vk::PipelineStageFlagBits::eComputeShader,
+        vk::AccessFlagBits::eShaderWrite,
+        vk::AccessFlagBits::eShaderRead);
+}
+
+void VkContext::ExecutionBarrier(
+    vk::CommandBuffer& cmds,
+    vk::PipelineStageFlags srcStage,
+    vk::PipelineStageFlags dstStage)
+{
+    cmds.pipelineBarrier(
+        srcStage, dstStage, (vk::DependencyFlags)0, 0, nullptr, 0, nullptr, 0, nullptr);
+}
+
 } // namespace vkapi

--- a/vulkan-api/src/vulkan-api/context.h
+++ b/vulkan-api/src/vulkan-api/context.h
@@ -74,6 +74,19 @@ public:
 
     uint32_t selectMemoryType(uint32_t flags, vk::MemoryPropertyFlags reqs);
 
+    static void GlobalBarrier(
+        vk::CommandBuffer& cmds,
+        vk::PipelineStageFlags srcStage,
+        vk::PipelineStageFlags dstStage,
+        vk::AccessFlags srcAccess,
+        vk::AccessFlags dstAccess);
+
+    static void writeReadComputeBarrier(vk::CommandBuffer& cmds);
+
+    static void ExecutionBarrier(
+        vk::CommandBuffer& cmds, vk::PipelineStageFlags srcStage, vk::PipelineStageFlags dstStage);
+
+
     // All the getters
     const vk::Instance& instance() const { return instance_; }
     const vk::Device& device() const { return device_; }

--- a/vulkan-api/src/vulkan-api/driver.cpp
+++ b/vulkan-api/src/vulkan-api/driver.cpp
@@ -567,7 +567,8 @@ void VkDriver::dispatchCompute(
     PipelineLayout& plineLayout = bundle->getPipelineLayout();
 
     // image storage
-    vkapi::PipelineCache::DescriptorImage storageImages[vkapi::PipelineCache::MaxStorageImageBindCount];
+    vkapi::PipelineCache::DescriptorImage
+        storageImages[vkapi::PipelineCache::MaxStorageImageBindCount];
     for (int idx = 0; idx < vkapi::PipelineCache::MaxStorageImageBindCount; ++idx)
     {
         const vkapi::TextureHandle& handle = bundle->storageImages_[idx];

--- a/vulkan-api/src/vulkan-api/pipeline_cache.cpp
+++ b/vulkan-api/src/vulkan-api/pipeline_cache.cpp
@@ -576,7 +576,6 @@ void PipelineCache::createDescriptorSets(
                             vk::DescriptorImageInfo& imageInfo,
                             vk::DescriptorSet set,
                             size_t binding) -> void {
-        ASSERT_FATAL(desc.imageSampler, "Image sampler not set for descriptor binding %d", binding);
         ASSERT_FATAL(desc.imageView, "Image view not set for descriptor binding %d", binding);
         ASSERT_FATAL(set, "Descriptor set is NULL.");
 
@@ -604,7 +603,7 @@ void PipelineCache::createDescriptorSets(
     }
     for (uint8_t bind = 0; bind < MaxStorageImageBindCount; ++bind)
     {
-        if (descRequires_.storageImages[bind].imageSampler)
+        if (descRequires_.storageImages[bind].imageView)
         {
             vk::DescriptorImageInfo& imageInfo = storageImageInfos[bind];
             writeDescSet(

--- a/vulkan-api/src/vulkan-api/pipeline_cache.h
+++ b/vulkan-api/src/vulkan-api/pipeline_cache.h
@@ -52,7 +52,7 @@ public:
     constexpr static uint8_t MaxUboDynamicBindCount = 4;
     constexpr static uint8_t MaxSsboBindCount = 4;
     constexpr static uint8_t MaxVertexAttributeCount = 8;
-    constexpr static uint8_t MaxStorageImageBindCount = 4;
+    constexpr static uint8_t MaxStorageImageBindCount = 6;
 
     // shader set values for each descriptor type
     constexpr static uint8_t UboSetValue = 0;

--- a/vulkan-api/src/vulkan-api/program_manager.cpp
+++ b/vulkan-api/src/vulkan-api/program_manager.cpp
@@ -288,12 +288,13 @@ void ShaderProgramBundle::setImageSampler(
     imageSamplers_[binding] = {handle, sampler};
 }
 
-void ShaderProgramBundle::setStorageImage(
-    const TextureHandle& handle, uint8_t binding)
+void ShaderProgramBundle::setStorageImage(const TextureHandle& handle, uint8_t binding)
 {
     ASSERT_FATAL(handle, "Invalid texture handle.");
     ASSERT_FATAL(
-        binding < PipelineCache::MaxStorageImageBindCount, "Binding of %d is out of bounds.", binding);
+        binding < PipelineCache::MaxStorageImageBindCount,
+        "Binding of %d is out of bounds.",
+        binding);
     storageImages_[binding] = handle;
 }
 

--- a/vulkan-api/src/vulkan-api/program_manager.h
+++ b/vulkan-api/src/vulkan-api/program_manager.h
@@ -157,7 +157,10 @@ public:
 
     void parseMaterialShader(const std::filesystem::path& shaderPath);
 
-    void setTexture(const TextureHandle& handle, uint8_t binding, vk::Sampler sampler);
+   void setImageSampler(
+        const TextureHandle& handle, uint8_t binding, vk::Sampler sampler);
+
+    void setStorageImage(const TextureHandle& handle, uint8_t binding);
 
     void setPushBlockData(backend::ShaderStage stage, void* data);
 
@@ -212,12 +215,19 @@ private:
     std::unique_ptr<PipelineLayout> pipelineLayout_;
 
     // Note: this is initialised after a call to updateDescriptorLayouts.
-    std::unique_ptr<PipelineLayout::PushBlockBindParams> pushBlock_[2];
+    std::unique_ptr<PipelineLayout::PushBlockBindParams>
+        pushBlock_[util::ecast(backend::ShaderStage::Count)];
+
+    struct ImageSamplerParams
+    {
+        TextureHandle texHandle;
+        vk::Sampler sampler;
+    };
 
     // Index into the resource cache for the texture for each attachment.
-    std::array<TextureHandle, PipelineCache::MaxSamplerBindCount> textureHandles_;
+    std::array<ImageSamplerParams, PipelineCache::MaxSamplerBindCount> imageSamplers_;
 
-    std::array<vk::Sampler, PipelineCache::MaxSamplerBindCount> samplers_;
+    std::array<TextureHandle, PipelineCache::MaxStorageImageBindCount> storageImages_;
 
     // We keep a record of descriptors here and their binding info for
     // use at the pipeline binding draw stage

--- a/vulkan-api/src/vulkan-api/program_manager.h
+++ b/vulkan-api/src/vulkan-api/program_manager.h
@@ -157,8 +157,7 @@ public:
 
     void parseMaterialShader(const std::filesystem::path& shaderPath);
 
-   void setImageSampler(
-        const TextureHandle& handle, uint8_t binding, vk::Sampler sampler);
+    void setImageSampler(const TextureHandle& handle, uint8_t binding, vk::Sampler sampler);
 
     void setStorageImage(const TextureHandle& handle, uint8_t binding);
 

--- a/yave/CMakeLists.txt
+++ b/yave/CMakeLists.txt
@@ -39,6 +39,7 @@ target_sources(
     include/yave/object_manager.h
     include/yave/indirect_light.h
     include/yave/options.h
+    include/yave/wave_generator.h
     
     PRIVATE
     src/engine.cpp
@@ -62,6 +63,7 @@ target_sources(
     src/scene_ubo.cpp
     src/post_process.cpp
     src/compute.cpp
+    src/wave_generator.cpp
     src/managers/renderable_manager.cpp
     src/managers/component_manager.cpp
     src/managers/renderable_manager.cpp
@@ -100,6 +102,7 @@ target_sources(
     src/scene_ubo.h
     src/post_process.h
     src/compute.h
+    src/wave_generator.h
     src/managers/component_manager.h
     src/managers/renderable_manager.h
     src/managers/transform_manager.h

--- a/yave/include/yave/engine.h
+++ b/yave/include/yave/engine.h
@@ -46,6 +46,7 @@ class Skybox;
 class IndirectLight;
 class Camera;
 class Window;
+class WaveGenerator;
 
 class Engine
 {
@@ -86,6 +87,8 @@ public:
     virtual IndirectLight* createIndirectLight() = 0;
 
     virtual Camera* createCamera() = 0;
+
+    virtual WaveGenerator* createWaveGenerator() = 0;
 
     virtual void flushCmds() = 0;
 

--- a/yave/include/yave/renderer.h
+++ b/yave/include/yave/renderer.h
@@ -93,7 +93,11 @@ public:
     virtual void endFrame() = 0;
 
     virtual void render(
-        Engine* engine, Scene* scene, float dt, util::Timer<NanoSeconds>& timer, bool clearSwap = true) = 0;
+        Engine* engine,
+        Scene* scene,
+        float dt,
+        util::Timer<NanoSeconds>& timer,
+        bool clearSwap = true) = 0;
 
     virtual void renderSingleScene(Engine* engine, Scene* scene, RenderTarget& rTarget) = 0;
 

--- a/yave/include/yave/renderer.h
+++ b/yave/include/yave/renderer.h
@@ -24,6 +24,7 @@
 #include <backend/enums.h>
 #include <utility/colour.h>
 #include <utility/cstring.h>
+#include <utility/timer.h>
 #include <vulkan-api/renderpass.h>
 
 #include <memory>
@@ -91,7 +92,8 @@ public:
 
     virtual void endFrame() = 0;
 
-    virtual void render(Engine* engine, Scene* scene, float dt, bool clearSwap = true) = 0;
+    virtual void render(
+        Engine* engine, Scene* scene, float dt, util::Timer<NanoSeconds>& timer, bool clearSwap = true) = 0;
 
     virtual void renderSingleScene(Engine* engine, Scene* scene, RenderTarget& rTarget) = 0;
 

--- a/yave/include/yave/texture_sampler.h
+++ b/yave/include/yave/texture_sampler.h
@@ -32,6 +32,7 @@ class TextureSampler
 public:
     TextureSampler() = default;
 
+    TextureSampler(backend::SamplerFilter minMag) { params_ = {minMag, minMag}; }
     TextureSampler(backend::SamplerFilter min, backend::SamplerFilter mag) { params_ = {min, mag}; }
 
     TextureSampler(
@@ -62,6 +63,7 @@ public:
     }
 
     backend::TextureSamplerParams& get() noexcept { return params_; }
+    backend::TextureSamplerParams get() const noexcept { return params_; }
 
 private:
     backend::TextureSamplerParams params_;

--- a/yave/include/yave/wave_generator.h
+++ b/yave/include/yave/wave_generator.h
@@ -27,12 +27,10 @@ namespace yave
 class WaveGenerator
 {
 public:
-
     virtual ~WaveGenerator();
 
 protected:
-
     WaveGenerator();
 };
 
-}
+} // namespace yave

--- a/yave/include/yave/wave_generator.h
+++ b/yave/include/yave/wave_generator.h
@@ -21,47 +21,18 @@
  */
 #pragma once
 
-#include "options.h"
-
-#include <memory>
-
 namespace yave
 {
-class Skybox;
-class Camera;
-class Object;
-class IndirectLight;
-class WaveGenerator;
 
-class Scene
+class WaveGenerator
 {
 public:
-    virtual ~Scene();
 
-    virtual void setSkybox(Skybox* skybox) = 0;
-
-    virtual void setIndirectLight(IndirectLight* il) = 0;
-
-    virtual void setCamera(Camera* camera) = 0;
-
-    virtual void setWaveGenerator(WaveGenerator* waterGen) = 0;
-
-    virtual Camera* getCurrentCamera() = 0;
-
-    virtual void addObject(Object obj) = 0;
-    virtual void destroyObject(Object obj) = 0;
-
-    virtual void usePostProcessing(bool state) = 0;
-
-    virtual void useGbuffer(bool state) = 0;
-
-    virtual void setBloomOptions(const BloomOptions& bloom) = 0;
-    virtual void setGbufferOptions(const GbufferOptions& gb) = 0;
-    virtual BloomOptions& getBloomOptions() = 0;
-    virtual GbufferOptions& getGbufferOptions() = 0;
+    virtual ~WaveGenerator();
 
 protected:
-    Scene();
+
+    WaveGenerator();
 };
 
-} // namespace yave
+}

--- a/yave/src/compute.cpp
+++ b/yave/src/compute.cpp
@@ -25,10 +25,9 @@
 #include "engine.h"
 #include "mapped_texture.h"
 
+#include <spdlog/spdlog.h>
 #include <vulkan-api/common.h>
 #include <vulkan-api/sampler_cache.h>
-
-#include <spdlog/spdlog.h>
 
 namespace yave
 {
@@ -37,7 +36,7 @@ Compute::Compute(IEngine& engine) : extSsboRead_(nullptr)
 {
     ubo_ = std::make_unique<UniformBuffer>(
         vkapi::PipelineCache::UboSetValue, UboBindPoint, "ComputeUbo", "compute_ubo");
-    
+
     pushBlock_ = std::make_unique<PushBlock>("PushBlock", "push_params");
 
     bundle_ = engine.driver().progManager().createProgramBundle();
@@ -76,9 +75,10 @@ void Compute::addImageSampler(
     const TextureSampler& sampler)
 {
     // all samplers use the same set
-    samplerSet_.pushSampler(name, vkapi::PipelineCache::SamplerSetValue, binding, SamplerSet::SamplerType::e2d);
+    samplerSet_.pushSampler(
+        name, vkapi::PipelineCache::SamplerSetValue, binding, SamplerSet::SamplerType::e2d);
 
-     bundle_->setImageSampler(
+    bundle_->setImageSampler(
         texture, binding, driver.getSamplerCache().createSampler(sampler.get()));
 }
 
@@ -109,13 +109,10 @@ void Compute::addSsbo(
     if (!ssbos_[binding])
     {
         ssbos_[binding] = std::make_unique<StorageBuffer>(
-            accessType,
-            vkapi::PipelineCache::SsboSetValue,
-            binding,
-            bufferName,
-            aliasName);
-        ssbos_[binding]->addElement(elementName, type, values, outerArraySize, innerArraySize, structName);
-    }      
+            accessType, vkapi::PipelineCache::SsboSetValue, binding, bufferName, aliasName);
+        ssbos_[binding]->addElement(
+            elementName, type, values, outerArraySize, innerArraySize, structName);
+    }
 }
 
 void Compute::copySsbo(
@@ -153,9 +150,7 @@ void Compute::copySsbo(
 }
 
 void Compute::addPushConstantParam(
-    const std::string& elementName,
-    backend::BufferElementType type,
-    void* value)
+    const std::string& elementName, backend::BufferElementType type, void* value)
 {
     pushBlock_->addElement(elementName, type, (void*)value);
 }
@@ -165,7 +160,7 @@ void Compute::updatePushConstantParam(const std::string& elementName, void* valu
     pushBlock_->updateElement(elementName, value);
 }
 
-void Compute::updateGpuPush() noexcept 
+void Compute::updateGpuPush() noexcept
 {
     if (!pushBlock_->empty())
     {
@@ -202,7 +197,7 @@ vkapi::ShaderProgramBundle* Compute::build(IEngine& engine, const std::string& c
             ASSERT_LOG(!ssbos_[i]->empty());
             program->addAttributeBlock(ssbos_[i]->createShaderStr());
             ssbos_[i]->createGpuBuffer(driver);
-            
+
             void* data = ssbos_[i]->getBlockData();
             if (data)
             {
@@ -214,7 +209,7 @@ vkapi::ShaderProgramBundle* Compute::build(IEngine& engine, const std::string& c
         }
     }
 
-    // storage images 
+    // storage images
     if (!imageStorageSet_.empty())
     {
         program->addAttributeBlock(imageStorageSet_.createShaderStr());

--- a/yave/src/compute.cpp
+++ b/yave/src/compute.cpp
@@ -28,6 +28,8 @@
 #include <vulkan-api/common.h>
 #include <vulkan-api/sampler_cache.h>
 
+#include <spdlog/spdlog.h>
+
 namespace yave
 {
 
@@ -35,35 +37,22 @@ Compute::Compute(IEngine& engine) : extSsboRead_(nullptr)
 {
     ubo_ = std::make_unique<UniformBuffer>(
         vkapi::PipelineCache::UboSetValue, UboBindPoint, "ComputeUbo", "compute_ubo");
-
-    readSsbo_ = std::make_unique<StorageBuffer>(
-        StorageBuffer::AccessType::ReadWrite,
-        vkapi::PipelineCache::SsboSetValue,
-        SsboReadOnlyBindPoint,
-        "ComputeReadSsbo",
-        "input_ssbo");
-
-    writeSsbo_ = std::make_unique<StorageBuffer>(
-        StorageBuffer::AccessType::ReadWrite,
-        vkapi::PipelineCache::SsboSetValue,
-        SsboWriteOnlyBindPoint,
-        "ComputeWriteSsbo",
-        "output_ssbo");
+    
+    pushBlock_ = std::make_unique<PushBlock>("PushBlock", "push_params");
 
     bundle_ = engine.driver().progManager().createProgramBundle();
 }
 Compute::~Compute() {}
 
-void Compute::addSamplerTexture(
+void Compute::addStorageImage(
     vkapi::VkDriver& driver,
     const std::string& name,
     const vkapi::TextureHandle& texture,
-    const backend::TextureSamplerParams& params,
     uint32_t binding,
     ImageStorageSet::StorageType storageType)
 {
     ASSERT_FATAL(
-        binding < vkapi::PipelineCache::MaxSamplerBindCount,
+        binding < vkapi::PipelineCache::MaxStorageImageBindCount,
         "Out of range for texture binding (=%d). Max allowed count is %d\n",
         binding,
         vkapi::PipelineCache::MaxSamplerBindCount);
@@ -76,7 +65,21 @@ void Compute::addSamplerTexture(
         storageType,
         ImageStorageSet::texFormatToFormatLayout(texture.getResource()->context().format));
 
-    bundle_->setTexture(texture, binding, driver.getSamplerCache().createSampler(params));
+    bundle_->setStorageImage(texture, binding);
+}
+
+void Compute::addImageSampler(
+    vkapi::VkDriver& driver,
+    const std::string& name,
+    const vkapi::TextureHandle& texture,
+    uint8_t binding,
+    const TextureSampler& sampler)
+{
+    // all samplers use the same set
+    samplerSet_.pushSampler(name, vkapi::PipelineCache::SamplerSetValue, binding, SamplerSet::SamplerType::e2d);
+
+     bundle_->setImageSampler(
+        texture, binding, driver.getSamplerCache().createSampler(sampler.get()));
 }
 
 void Compute::addUboParam(
@@ -85,44 +88,91 @@ void Compute::addUboParam(
     ubo_->addElement(elementName, type, (void*)value, arrayCount);
 }
 
-void Compute::addSsboReadParam(
-    const std::string& elementName, void* values, const std::string& structName, uint32_t arraySize)
-{
-    readSsbo_->addElement(
-        elementName, backend::BufferElementType::Struct, values, arraySize, structName);
-}
-
-void Compute::addSsboWriteParam(
-    const std::string& elementName, const std::string& structName, uint32_t arraySize)
-{
-    writeSsbo_->addElement(
-        elementName, backend::BufferElementType::Struct, nullptr, arraySize, structName);
-}
-
-void Compute::addSsboReadParam(
+void Compute::addSsbo(
     const std::string& elementName,
     backend::BufferElementType type,
+    StorageBuffer::AccessType accessType,
+    int binding,
+    const std::string& aliasName,
     void* values,
-    uint32_t arraySize)
+    uint32_t outerArraySize,
+    uint32_t innerArraySize,
+    const std::string& structName,
+    bool destroy)
 {
-    readSsbo_->addElement(elementName, type, values, arraySize);
+    ASSERT_FATAL(binding < MaxSsboCount, "Binding out of range.");
+    std::string bufferName = "SsboBuffer" + std::to_string(binding);
+    if (ssbos_[binding] && destroy)
+    {
+        ssbos_[binding].reset();
+    }
+    if (!ssbos_[binding])
+    {
+        ssbos_[binding] = std::make_unique<StorageBuffer>(
+            accessType,
+            vkapi::PipelineCache::SsboSetValue,
+            binding,
+            bufferName,
+            aliasName);
+        ssbos_[binding]->addElement(elementName, type, values, outerArraySize, innerArraySize, structName);
+    }      
 }
 
-void Compute::addSsboWriteParam(
-    const std::string& elementName, backend::BufferElementType type, uint32_t arraySize)
-{
-    writeSsbo_->addElement(elementName, type, nullptr, arraySize);
-}
-
-void Compute::addExternalSsboRead(const Compute& compute)
+void Compute::copySsbo(
+    const Compute& fromCompute,
+    int fromId,
+    int toId,
+    StorageBuffer::AccessType toAccessType,
+    const std::string& toSsboName,
+    const std::string& toAliasName,
+    bool destroy)
 {
     ASSERT_FATAL(
-        !compute.writeSsbo_->empty(),
+        fromCompute.ssbos_[fromId] && !fromCompute.ssbos_[fromId]->empty(),
         "The write-only ssbo must have been written to in another compute call before being used "
         "as a reader.");
+    ASSERT_FATAL(
+        toId < MaxSsboCount, "Can not copy ssbo to id {} and exceed max bind count.", toId);
+
     // copy the write ssbo details to the read including the GPU buffer address that contains
     // the write contents from the last stage.
-    readSsbo_->copyFrom(*compute.writeSsbo_);
+    if (destroy)
+    {
+        ssbos_[toId].reset();
+    }
+    if (!ssbos_[toId])
+    {
+        ssbos_[toId] = std::make_unique<StorageBuffer>(
+            toAccessType,
+            vkapi::PipelineCache::SsboSetValue,
+            SsboBindPoint + toId,
+            toSsboName,
+            toAliasName);
+        ssbos_[toId]->copyFrom(*fromCompute.ssbos_[fromId]);
+    }
+}
+
+void Compute::addPushConstantParam(
+    const std::string& elementName,
+    backend::BufferElementType type,
+    void* value)
+{
+    pushBlock_->addElement(elementName, type, (void*)value);
+}
+
+void Compute::updatePushConstantParam(const std::string& elementName, void* value)
+{
+    pushBlock_->updateElement(elementName, value);
+}
+
+void Compute::updateGpuPush() noexcept 
+{
+    if (!pushBlock_->empty())
+    {
+        void* data = pushBlock_->getBlockData();
+        ASSERT_LOG(data);
+        bundle_->setPushBlockData(backend::ShaderStage::Compute, data);
+    }
 }
 
 vkapi::ShaderProgramBundle* Compute::build(IEngine& engine, const std::string& compShader)
@@ -144,34 +194,40 @@ vkapi::ShaderProgramBundle* Compute::build(IEngine& engine, const std::string& c
     auto params = ubo_->getBufferParams(driver);
     bundle_->addDescriptorBinding(params.size, params.binding, params.buffer, params.type);
 
-    // read ssbo
-    // Note: we don't map storage buffers used for compute as we assume the write ssbo will
-    // be written by the compute and this will then be read. This might not always be the
-    // case so may need changing at some point.
-    if (!readSsbo_->empty())
+    // storage buffers
+    for (int i = 0; i < MaxSsboCount; ++i)
     {
-        program->addAttributeBlock(readSsbo_->createShaderStr());
-        readSsbo_->createGpuBuffer(driver);
+        if (ssbos_[i])
+        {
+            ASSERT_LOG(!ssbos_[i]->empty());
+            program->addAttributeBlock(ssbos_[i]->createShaderStr());
+            ssbos_[i]->createGpuBuffer(driver);
+            
+            void* data = ssbos_[i]->getBlockData();
+            if (data)
+            {
+                ssbos_[i]->mapGpuBuffer(driver, data);
+            }
 
-        params = readSsbo_->getBufferParams(driver);
-        bundle_->addDescriptorBinding(params.size, params.binding, params.buffer, params.type);
+            params = ssbos_[i]->getBufferParams(driver);
+            bundle_->addDescriptorBinding(params.size, params.binding, params.buffer, params.type);
+        }
     }
 
-    // write ssbo
-    if (!writeSsbo_->empty())
-    {
-        program->addAttributeBlock(writeSsbo_->createShaderStr());
-        writeSsbo_->createGpuBuffer(driver);
-
-        params = writeSsbo_->getBufferParams(driver);
-        bundle_->addDescriptorBinding(params.size, params.binding, params.buffer, params.type);
-    }
-
-    // samplers
+    // storage images 
     if (!imageStorageSet_.empty())
     {
         program->addAttributeBlock(imageStorageSet_.createShaderStr());
     }
+
+    // image samplers
+    if (!samplerSet_.empty())
+    {
+        program->addAttributeBlock(samplerSet_.createShaderStr());
+    }
+
+    // push block
+    program->addAttributeBlock(pushBlock_->createShaderStr());
 
     vkapi::Shader* shader = manager.findShaderVariantOrCreate(
         {}, backend::ShaderStage::Compute, vk::PrimitiveTopology::eTriangleList, bundle_);

--- a/yave/src/compute.h
+++ b/yave/src/compute.h
@@ -42,19 +42,25 @@ class Compute
 {
 public:
     static constexpr int UboBindPoint = 0;
-    static constexpr int SsboReadOnlyBindPoint = 1;
-    static constexpr int SsboWriteOnlyBindPoint = 2;
+    static constexpr int SsboBindPoint = 1;
+    static constexpr int MaxSsboCount = 5;
 
     Compute(IEngine& engine);
     ~Compute();
 
-    void addSamplerTexture(
+    void addStorageImage(
         vkapi::VkDriver& driver,
         const std::string& name,
         const vkapi::TextureHandle& handle,
-        const backend::TextureSamplerParams& params,
         uint32_t binding,
         ImageStorageSet::StorageType storageType);
+
+    void addImageSampler(
+        vkapi::VkDriver& driver,
+        const std::string& name,
+        const vkapi::TextureHandle& texture,
+        uint8_t binding,
+        const TextureSampler& sampler);
 
     void addUboParam(
         const std::string& elementName,
@@ -62,36 +68,47 @@ public:
         void* value,
         size_t arrayCount = 1);
 
-    // custom struct version
-    void addSsboReadParam(
-        const std::string& elementName,
-        void* values,
-        const std::string& structName,
-        uint32_t arraySize = 0);
-
-    void addSsboWriteParam(
-        const std::string& elementName, const std::string& structName, uint32_t arraySize = 0);
-
-    void addSsboReadParam(
+    void addSsbo(
         const std::string& elementName,
         backend::BufferElementType type,
-        void* values,
-        uint32_t arraySize = 0);
+        StorageBuffer::AccessType accessType,
+        int binding,
+        const std::string& aliasName,
+        void* values = nullptr,
+        uint32_t outerArraySize = 0,
+        uint32_t innerArraySize = 1,
+        const std::string& structName = "",
+        bool destroy = false);
 
-    void addSsboWriteParam(
-        const std::string& elementName, backend::BufferElementType type, uint32_t arraySize = 0);
+    void addPushConstantParam(
+        const std::string& elementName,
+        backend::BufferElementType type,
+        void* value = nullptr);
 
-    // add the write-only ssbo as a reader to a compute shader - must have been written to
+    void updatePushConstantParam(const std::string& elementName, void* value);
+
+    void updateGpuPush() noexcept;
+
+    // add a previously declared ssbo as a reader/writer to another compute shader - must have been declared/written to
     // in a seperate dispatch call.
-    void addExternalSsboRead(const Compute& compute);
+    void copySsbo(
+        const Compute& fromCompute,
+        int fromId,
+        int toId,
+        StorageBuffer::AccessType toAccessType,
+        const std::string& toSsboName,
+        const std::string& toAliasName,
+        bool destroy = false);
 
     vkapi::ShaderProgramBundle* build(IEngine& engine, const std::string& compShader);
 
 private:
-    std::unique_ptr<StorageBuffer> readSsbo_;
-    std::unique_ptr<StorageBuffer> writeSsbo_;
+    std::unique_ptr<StorageBuffer> ssbos_[MaxSsboCount];
     std::unique_ptr<UniformBuffer> ubo_;
+    std::unique_ptr<PushBlock> pushBlock_;
+
     ImageStorageSet imageStorageSet_;
+    SamplerSet samplerSet_;
 
     StorageBuffer* extSsboRead_;
 

--- a/yave/src/compute.h
+++ b/yave/src/compute.h
@@ -81,16 +81,14 @@ public:
         bool destroy = false);
 
     void addPushConstantParam(
-        const std::string& elementName,
-        backend::BufferElementType type,
-        void* value = nullptr);
+        const std::string& elementName, backend::BufferElementType type, void* value = nullptr);
 
     void updatePushConstantParam(const std::string& elementName, void* value);
 
     void updateGpuPush() noexcept;
 
-    // add a previously declared ssbo as a reader/writer to another compute shader - must have been declared/written to
-    // in a seperate dispatch call.
+    // add a previously declared ssbo as a reader/writer to another compute shader - must have been
+    // declared/written to in a seperate dispatch call.
     void copySsbo(
         const Compute& fromCompute,
         int fromId,

--- a/yave/src/engine.cpp
+++ b/yave/src/engine.cpp
@@ -30,6 +30,7 @@
 #include "mapped_texture.h"
 #include "post_process.h"
 #include "renderable.h"
+#include "wave_generator.h"
 #include "scene.h"
 #include "skybox.h"
 #include "utility/timer.h"
@@ -203,6 +204,8 @@ IIndirectLight* IEngine::createIndirectLightI() noexcept { return createResource
 
 ICamera* IEngine::createCameraI() noexcept { return createResource(cameras_); }
 
+IWaveGenerator* IEngine::createWaveGeneratorI() noexcept { return createResource(waterGens_, *this); }
+
 void IEngine::flush()
 {
     auto& cmds = driver_->getCommands();
@@ -315,6 +318,11 @@ IndirectLight* IEngine::createIndirectLight()
 }
 
 Camera* IEngine::createCamera() { return reinterpret_cast<Camera*>(createCameraI()); }
+
+WaveGenerator* IEngine::createWaveGenerator()
+{
+    return reinterpret_cast<WaveGenerator*>(createWaveGeneratorI());
+}
 
 void IEngine::flushCmds() { flush(); }
 

--- a/yave/src/engine.cpp
+++ b/yave/src/engine.cpp
@@ -30,11 +30,11 @@
 #include "mapped_texture.h"
 #include "post_process.h"
 #include "renderable.h"
-#include "wave_generator.h"
 #include "scene.h"
 #include "skybox.h"
 #include "utility/timer.h"
 #include "vulkan-api/swapchain.h"
+#include "wave_generator.h"
 #include "yave/renderable.h"
 
 #include <yave_app/window.h>
@@ -204,7 +204,10 @@ IIndirectLight* IEngine::createIndirectLightI() noexcept { return createResource
 
 ICamera* IEngine::createCameraI() noexcept { return createResource(cameras_); }
 
-IWaveGenerator* IEngine::createWaveGeneratorI() noexcept { return createResource(waterGens_, *this); }
+IWaveGenerator* IEngine::createWaveGeneratorI() noexcept
+{
+    return createResource(waterGens_, *this);
+}
 
 void IEngine::flush()
 {

--- a/yave/src/engine.h
+++ b/yave/src/engine.h
@@ -36,6 +36,7 @@
 #include "yave/engine.h"
 #include "yave/light_manager.h"
 #include "yave/renderable_manager.h"
+#include "yave/wave_generator.h"
 
 #include <deque>
 #include <filesystem>
@@ -56,6 +57,7 @@ class IMappedTexture;
 class ISkybox;
 class IIndirectLight;
 class ICamera;
+class IWaveGenerator;
 
 using SwapchainHandle = vkapi::SwapchainHandle;
 
@@ -82,6 +84,7 @@ public:
     ISkybox* createSkyboxI(IScene& scene) noexcept;
     IIndirectLight* createIndirectLightI() noexcept;
     ICamera* createCameraI() noexcept;
+    IWaveGenerator* createWaveGeneratorI() noexcept;
 
     void setCurrentSwapchainI(const SwapchainHandle& handle) noexcept;
     vkapi::Swapchain* getCurrentSwapchain() noexcept;
@@ -144,6 +147,7 @@ public:
     Skybox* createSkybox(Scene* scene) override;
     IndirectLight* createIndirectLight() override;
     Camera* createCamera() override;
+    WaveGenerator* createWaveGenerator() override;
     void flushCmds() override;
 
     void destroy(VertexBuffer* buffer) override;
@@ -175,6 +179,7 @@ private:
     std::unordered_set<ISkybox*> skyboxes_;
     std::unordered_set<IIndirectLight*> indirectLights_;
     std::unordered_set<ICamera*> cameras_;
+    std::unordered_set<IWaveGenerator*> waterGens_;
     std::vector<vkapi::Swapchain*> swapchains_;
 
     vkapi::Swapchain* currentSwapchain_;

--- a/yave/src/managers/light_manager.cpp
+++ b/yave/src/managers/light_manager.cpp
@@ -48,7 +48,7 @@ ILightManager::ILightManager(IEngine& engine)
         "LightSsbo",
         "light_ssbo");
 
-    ssbo_->addElement("params", backend::BufferElementType::Struct, nullptr, 0, "LightParams");
+    ssbo_->addElement("params", backend::BufferElementType::Struct, nullptr, 0, 1, "LightParams");
     ssbo_->createGpuBuffer(engine_.driver(), MaxLightCount * sizeof(ILightManager::LightSsbo));
 
     // A sampler for each of the gbuffer render targets.
@@ -453,15 +453,15 @@ rg::RenderGraphHandle ILightManager::render(
                 1.0f);
             vk::Sampler sampler =
                 engine_.driver().getSamplerCache().createSampler(samplerParams.get());
-            programBundle_->setTexture(
+            programBundle_->setImageSampler(
                 resources.getTextureHandle(data.position), SamplerPositionBinding, sampler);
-            programBundle_->setTexture(
+            programBundle_->setImageSampler(
                 resources.getTextureHandle(data.colour), SamplerColourBinding, sampler);
-            programBundle_->setTexture(
+            programBundle_->setImageSampler(
                 resources.getTextureHandle(data.normal), SamplerNormalBinding, sampler);
-            programBundle_->setTexture(
+            programBundle_->setImageSampler(
                 resources.getTextureHandle(data.pbr), SamplerPbrBinding, sampler);
-            programBundle_->setTexture(
+            programBundle_->setImageSampler(
                 resources.getTextureHandle(data.emissive), SamplerEmissiveBinding, sampler);
 
             TextureSampler iblSamplerParams(
@@ -475,23 +475,24 @@ rg::RenderGraphHandle ILightManager::render(
             IIndirectLight* il = scene.getIndirectLight();
             if (il)
             {
-                programBundle_->setTexture(
+                programBundle_->setImageSampler(
                     il->getIrradianceMapHandle(), SamplerIrradianceBinding, iblSampler);
-                programBundle_->setTexture(
+                programBundle_->setImageSampler(
                     il->getSpecularMapHandle(), SamplerSpecularBinding, iblSampler);
-                programBundle_->setTexture(il->getBrdfLutHandle(), SamplerBrdfBinding, iblSampler);
+                programBundle_->setImageSampler(
+                    il->getBrdfLutHandle(), SamplerBrdfBinding, iblSampler);
             }
             else
             {
-                programBundle_->setTexture(
+                programBundle_->setImageSampler(
                     engine_.getDummyIrradianceMap()->getBackendHandle(),
                     SamplerIrradianceBinding,
                     sampler);
-                programBundle_->setTexture(
+                programBundle_->setImageSampler(
                     engine_.getDummySpecularMap()->getBackendHandle(),
                     SamplerSpecularBinding,
                     sampler);
-                programBundle_->setTexture(
+                programBundle_->setImageSampler(
                     engine_.getDummyBrdfLut()->getBackendHandle(), SamplerBrdfBinding, sampler);
             }
 

--- a/yave/src/material.cpp
+++ b/yave/src/material.cpp
@@ -224,7 +224,7 @@ void IMaterial::addImageTexture(
     setSamplerParamI(imageTypeToStr(type), binding, samplerType);
 
     params.mipLevels = texture->getMipLevels();
-    programBundle_->setTexture(
+    programBundle_->setImageSampler(
         texture->getBackendHandle(), binding, driver.getSamplerCache().createSampler(params));
 }
 
@@ -235,7 +235,8 @@ void IMaterial::addImageTexture(
     const backend::TextureSamplerParams& params)
 {
     uint32_t binding = samplerSet_.getSamplerBinding(samplerName);
-    programBundle_->setTexture(handle, binding, driver.getSamplerCache().createSampler(params));
+    programBundle_->setImageSampler(
+        handle, binding, driver.getSamplerCache().createSampler(params));
 }
 
 void IMaterial::addBuffer(BufferBase* buffer, backend::ShaderStage type)
@@ -542,7 +543,7 @@ void IMaterial::addPushConstantParam(
     size_t size,
     void* value)
 {
-    addPushConstantParamI(elementName, type, stage, size, value);
+    addPushConstantParamI(elementName, type, stage, value);
 }
 
 void IMaterial::addUboParam(
@@ -651,6 +652,7 @@ void IMaterial::setEmissiveFactor(const util::Colour4& emissive) noexcept
         (void*)&emissive);
     addVariant(IMaterial::Variants::HasEmissiveFactor);
 }
+
 void IMaterial::setMaterialFactors(const MaterialFactors& factors)
 {
     setColourBaseFactor(factors.baseColourFactor);

--- a/yave/src/material.h
+++ b/yave/src/material.h
@@ -141,7 +141,6 @@ public:
         const std::string& elementName,
         backend::BufferElementType type,
         backend::ShaderStage stage,
-        size_t size,
         void* value)
     {
         pushBlock_[util::ecast(stage)]->addElement(elementName, type, (void*)value);

--- a/yave/src/post_process.cpp
+++ b/yave/src/post_process.cpp
@@ -153,13 +153,9 @@ rg::RenderGraphHandle PostProcess::bloom(
             vk::PipelineStageFlagBits::eComputeShader);
 
         lumCompute_->addStorageImage(
-            driver,
-            "ColourSampler",
-            lightHandle,
-            0,
-            ImageStorageSet::StorageType::ReadOnly);
+            driver, "ColourSampler", lightHandle, 0, ImageStorageSet::StorageType::ReadOnly);
 
-       lumCompute_->addSsbo(
+        lumCompute_->addSsbo(
             "histogram",
             backend::BufferElementType::Uint,
             StorageBuffer::AccessType::ReadWrite,
@@ -203,13 +199,8 @@ rg::RenderGraphHandle PostProcess::bloom(
             0,
             ImageStorageSet::StorageType::ReadWrite);
 
-         avgCompute_->copySsbo(
-            *lumCompute_,
-            0,
-            0,
-            StorageBuffer::AccessType::ReadWrite,
-            "SsboBuffer",
-            "input_ssbo");
+        avgCompute_->copySsbo(
+            *lumCompute_, 0, 0, StorageBuffer::AccessType::ReadWrite, "SsboBuffer", "input_ssbo");
 
         avgCompute_->addUboParam(
             "minLuminanceLog", backend::BufferElementType::Float, (void*)&options.minLuminanceLog);

--- a/yave/src/renderer.cpp
+++ b/yave/src/renderer.cpp
@@ -29,6 +29,7 @@
 #include "render_graph/resources.h"
 #include "scene.h"
 #include "skybox.h"
+#include "wave_generator.h"
 #include "utility/cstring.h"
 #include "vulkan-api/renderpass.h"
 
@@ -130,7 +131,8 @@ void IRenderer::renderSingleSceneI(vkapi::VkDriver& driver, IScene* scene, Rende
     driver.endRenderpass(cmdBuffer);
 }
 
-void IRenderer::renderI(vkapi::VkDriver& driver, IScene* scene, float dt, bool clearSwap)
+void IRenderer::renderI(
+    vkapi::VkDriver& driver, IScene* scene, float dt, util::Timer<NanoSeconds>& timer, bool clearSwap)
 {
     rGraph_.reset();
 
@@ -174,6 +176,13 @@ void IRenderer::renderI(vkapi::VkDriver& driver, IScene* scene, float dt, bool c
     if (!scene->withPostProcessing())
     {
         bloomOptions.enabled = false;
+    }
+
+    // upate the wave data - the actual draw happens in the material queue
+    IWaveGenerator* waveGen = scene->getWaveGenerator();
+    if (waveGen)
+    {
+        waveGen->render(rGraph_, *scene, dt, timer);
     }
 
     // fill the gbuffers - this can't be the final render target unless gbuffers are disabled due
@@ -223,12 +232,14 @@ void IRenderer::beginFrame() { beginFrameI(); }
 
 void IRenderer::endFrame() { endFrameI(); }
 
-void IRenderer::render(Engine* engine, Scene* scene, float dt, bool clearSwap)
+void IRenderer::render(
+    Engine* engine, Scene* scene, float dt, util::Timer<NanoSeconds>& timer, bool clearSwap)
 {
     renderI(
         reinterpret_cast<IEngine*>(engine)->driver(),
         reinterpret_cast<IScene*>(scene),
         dt,
+        timer,
         clearSwap);
 };
 

--- a/yave/src/renderer.cpp
+++ b/yave/src/renderer.cpp
@@ -29,9 +29,9 @@
 #include "render_graph/resources.h"
 #include "scene.h"
 #include "skybox.h"
-#include "wave_generator.h"
 #include "utility/cstring.h"
 #include "vulkan-api/renderpass.h"
+#include "wave_generator.h"
 
 #include <algorithm>
 
@@ -132,7 +132,11 @@ void IRenderer::renderSingleSceneI(vkapi::VkDriver& driver, IScene* scene, Rende
 }
 
 void IRenderer::renderI(
-    vkapi::VkDriver& driver, IScene* scene, float dt, util::Timer<NanoSeconds>& timer, bool clearSwap)
+    vkapi::VkDriver& driver,
+    IScene* scene,
+    float dt,
+    util::Timer<NanoSeconds>& timer,
+    bool clearSwap)
 {
     rGraph_.reset();
 

--- a/yave/src/renderer.h
+++ b/yave/src/renderer.h
@@ -51,7 +51,11 @@ public:
 
     void endFrameI() noexcept;
 
-    void renderI(vkapi::VkDriver& driver, IScene* scene, float dt, bool clearSwap = true);
+    void renderI(
+        vkapi::VkDriver& driver,
+        IScene* scene,
+        float dt,
+        util::Timer<NanoSeconds>& timer, bool clearSwap = true);
 
     // draws into a single render target
     void renderSingleSceneI(vkapi::VkDriver& driver, IScene* scene, RenderTarget& rTarget);
@@ -60,7 +64,8 @@ public:
 
     void beginFrame() override;
     void endFrame() override;
-    void render(Engine* engine, Scene* scene, float dt, bool clearSwap) override;
+    void render(
+        Engine* engine, Scene* scene, float dt, util::Timer<NanoSeconds>& timer, bool clearSwap) override;
     void renderSingleScene(Engine* engine, Scene* scene, RenderTarget& rTarget) override;
 
 private:

--- a/yave/src/renderer.h
+++ b/yave/src/renderer.h
@@ -55,7 +55,8 @@ public:
         vkapi::VkDriver& driver,
         IScene* scene,
         float dt,
-        util::Timer<NanoSeconds>& timer, bool clearSwap = true);
+        util::Timer<NanoSeconds>& timer,
+        bool clearSwap = true);
 
     // draws into a single render target
     void renderSingleSceneI(vkapi::VkDriver& driver, IScene* scene, RenderTarget& rTarget);
@@ -64,8 +65,9 @@ public:
 
     void beginFrame() override;
     void endFrame() override;
-    void render(
-        Engine* engine, Scene* scene, float dt, util::Timer<NanoSeconds>& timer, bool clearSwap) override;
+    void
+    render(Engine* engine, Scene* scene, float dt, util::Timer<NanoSeconds>& timer, bool clearSwap)
+        override;
     void renderSingleScene(Engine* engine, Scene* scene, RenderTarget& rTarget) override;
 
 private:

--- a/yave/src/scene.cpp
+++ b/yave/src/scene.cpp
@@ -49,6 +49,7 @@ IScene::IScene(IEngine& engine)
     : engine_(engine),
       camera_(nullptr),
       skybox_(nullptr),
+      waveGen_(nullptr),
       indirectLight_(nullptr),
       sceneUbo_(std::make_unique<SceneUbo>(engine_.driver())),
       usePostProcessing_(true),
@@ -95,6 +96,12 @@ void IScene::setCameraI(ICamera* cam) noexcept
 {
     ASSERT_FATAL(cam, "The camera is nullptr.");
     camera_ = cam;
+}
+
+void IScene::setWaveGeneratorI(IWaveGenerator* waterGen) noexcept 
+{
+    ASSERT_FATAL(waterGen, "Water generator is nullptr");
+    waveGen_ = waterGen;
 }
 
 bool IScene::update()
@@ -371,6 +378,11 @@ Scene::Scene() {}
 Scene::~Scene() {}
 
 void IScene::setSkybox(Skybox* skybox) { setSkyboxI(reinterpret_cast<ISkybox*>(skybox)); }
+
+void IScene::setWaveGenerator(WaveGenerator* waterGen)
+{
+    setWaveGeneratorI(reinterpret_cast<IWaveGenerator*>(waterGen));
+}
 
 void IScene::setIndirectLight(IndirectLight* il)
 {

--- a/yave/src/scene.cpp
+++ b/yave/src/scene.cpp
@@ -98,7 +98,7 @@ void IScene::setCameraI(ICamera* cam) noexcept
     camera_ = cam;
 }
 
-void IScene::setWaveGeneratorI(IWaveGenerator* waterGen) noexcept 
+void IScene::setWaveGeneratorI(IWaveGenerator* waterGen) noexcept
 {
     ASSERT_FATAL(waterGen, "Water generator is nullptr");
     waveGen_ = waterGen;

--- a/yave/src/scene.h
+++ b/yave/src/scene.h
@@ -46,6 +46,8 @@ class ICamera;
 class Frustum;
 class IEngine;
 class ISkybox;
+class IWaveGenerator;
+class WaveGenerator;
 
 class IScene : public Scene
 {
@@ -89,6 +91,8 @@ public:
 
     void setCameraI(ICamera* cam) noexcept;
 
+    void setWaveGeneratorI(IWaveGenerator* waterGen) noexcept;
+
     // ============== getters ============================
 
     ISkybox* getSkybox() noexcept { return skybox_; }
@@ -98,6 +102,7 @@ public:
     UniformBuffer& getTransUbo() noexcept { return *transUbo_; }
     UniformBuffer& getSkinUbo() noexcept { return *skinUbo_; }
     SceneUbo& getSceneUbo() noexcept { return *sceneUbo_; }
+    IWaveGenerator* getWaveGenerator() noexcept { return waveGen_; }
     bool withPostProcessing() const noexcept { return usePostProcessing_; }
     bool withGbuffer() const noexcept { return useGbuffer_; }
 
@@ -106,6 +111,7 @@ public:
     void setSkybox(Skybox* skybox) override;
     void setIndirectLight(IndirectLight* il) override;
     void setCamera(Camera* cam) override;
+    void setWaveGenerator(WaveGenerator* waterGen) override;
     Camera* getCurrentCamera() override;
     void addObject(Object obj) override;
     void destroyObject(Object obj) override;
@@ -125,6 +131,7 @@ private:
 
     // current skybox
     ISkybox* skybox_;
+    IWaveGenerator* waveGen_;
 
     IIndirectLight* indirectLight_;
 

--- a/yave/src/uniform_buffer.cpp
+++ b/yave/src/uniform_buffer.cpp
@@ -226,7 +226,8 @@ void BufferBase::addElement(
         newValue = new uint8_t[byteSize];
         memcpy(newValue, value, byteSize);
     }
-    elements_.push_back({name, type, byteSize, newValue, innerArraySize, outerArraySize, structName});
+    elements_.push_back(
+        {name, type, byteSize, newValue, innerArraySize, outerArraySize, structName});
     accumSize_ += byteSize;
 }
 
@@ -349,7 +350,8 @@ void UniformBuffer::createGpuBuffer(vkapi::VkDriver& driver) noexcept
 void UniformBuffer::mapGpuBuffer(vkapi::VkDriver& driver, void* data, size_t size) noexcept
 {
     vkapi::Buffer* buffer = vkHandle_.getResource();
-    ASSERT_FATAL(buffer, "Buffer is nullptr - have you created the buffer before trying to map data?");
+    ASSERT_FATAL(
+        buffer, "Buffer is nullptr - have you created the buffer before trying to map data?");
     buffer->mapToGpuBuffer(data, size);
 }
 

--- a/yave/src/uniform_buffer.h
+++ b/yave/src/uniform_buffer.h
@@ -56,8 +56,10 @@ public:
         uint32_t size;
         // the member value as binary
         void* value;
-        // the array size
-        uint32_t arraySize;
+        // the inner array size ( >1 indicates a 2d array)
+        uint32_t innerArraySize;
+        // the outer array size 
+        uint32_t outerArraySize;
         // name of the struct if the element type is "Struct"
         std::string structName;
     };
@@ -65,11 +67,14 @@ public:
     BufferBase();
     virtual ~BufferBase();
 
+    // Note: if both inner and outer array are > 1 then indicates a 2d array.
+    // id inner array == 1 then treated as a 1d array and only the outer array size considered.
     void addElement(
         const std::string& name,
         backend::BufferElementType type,
         void* value = nullptr,
-        uint32_t arraySize = 1,
+        uint32_t outerArraySize = 1,
+        uint32_t innerArraySize = 1,
         const std::string& structName = "") noexcept;
 
     void updateElement(const std::string& name, void* data) noexcept;

--- a/yave/src/uniform_buffer.h
+++ b/yave/src/uniform_buffer.h
@@ -58,7 +58,7 @@ public:
         void* value;
         // the inner array size ( >1 indicates a 2d array)
         uint32_t innerArraySize;
-        // the outer array size 
+        // the outer array size
         uint32_t outerArraySize;
         // name of the struct if the element type is "Struct"
         std::string structName;

--- a/yave/src/wave_generator.cpp
+++ b/yave/src/wave_generator.cpp
@@ -1,0 +1,482 @@
+/* Copyright (c) 2022 Garry Whitehead
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "wave_generator.h"
+#include "engine.h"
+#include "scene.h"
+#include "compute.h"
+#include "mapped_texture.h"
+#include "yave/texture_sampler.h"
+
+#include <image_utils/noise_generator.h>
+
+#include <random>
+
+namespace yave
+{
+
+IWaveGenerator::IWaveGenerator(IEngine& engine)
+    : engine_(engine),
+      initialSpecCompute_(std::make_unique<Compute>(engine)),
+      specCompute_(std::make_unique<Compute>(engine)),
+      butterflyCompute_(std::make_unique<Compute>(engine)),
+      fftHorizCompute_(std::make_unique<Compute>(engine)),
+      fftVertCompute_(std::make_unique<Compute>(engine)),
+      displaceCompute_(std::make_unique<Compute>(engine)),
+      genMapCompute_(std::make_unique<Compute>(engine)),
+      log2N_(std::log(Resolution) / log(2)),
+      pingpong_(0),
+      updateSpectrum_(true)
+{
+    auto reverse = [this](int idx) -> uint32_t {  
+        uint32_t res = 0;
+        for (int i = 0; i < log2N_; ++i)
+        {
+            res = (res << 1) + (idx & 1);
+            idx >>= 1;
+        }
+        return res;
+    };
+    
+    for (size_t index = 0; index < Resolution; ++index)
+    {
+        reversedBits_[index] = reverse(index);
+    }
+
+    // generate gaussian noise for initial spectrum (h0k)
+    std::random_device rd {};
+    std::mt19937 gen {rd()};
+    std::normal_distribution<float> d {0, 1};
+
+    for (int i = 0; i < Resolution; ++i)
+    {
+        for (int j = 0; j < Resolution * 4; j += 4)
+        {
+            int index = i * (Resolution * 4) + j;
+            noiseMap_[index] = d(gen);
+            noiseMap_[index + 1] = d(gen);
+            noiseMap_[index + 2] = d(gen);
+            noiseMap_[index + 3] = d(gen);
+        }
+    }
+    noiseTexture_ = engine.createMappedTextureI();
+    noiseTexture_->setTextureI(
+        noiseMap_,
+        Resolution * Resolution * 4 * sizeof(float),
+        Resolution,
+        Resolution,
+        1, 1,
+        Texture::TextureFormat::RGBA32F,
+        backend::ImageUsage::Storage);
+
+    butterflyLut_ = engine.createMappedTextureI();
+    butterflyLut_->setEmptyTexture(
+        log2N_,
+        Resolution,
+        Texture::TextureFormat::RGBA32F,
+        backend::ImageUsage::Storage,
+        1, 1);
+
+    // output textures for h0k and h0-k
+    h0kTexture_ = engine.createMappedTextureI();
+    h0minuskTexture_ = engine.createMappedTextureI();
+    h0kTexture_->setEmptyTexture(
+        Resolution, Resolution, Texture::TextureFormat::RGBA32F, backend::ImageUsage::Storage, 1, 1);
+    h0minuskTexture_->setEmptyTexture(
+        Resolution, Resolution, Texture::TextureFormat::RGBA32F, backend::ImageUsage::Storage, 1, 1);
+
+    // displacement
+    fftOutputImage_ = engine_.createMappedTextureI();
+    fftOutputImage_->setEmptyTexture(
+        Resolution,
+        Resolution,
+        Texture::TextureFormat::RG32F,
+        backend::ImageUsage::Storage,
+        1,
+        1);
+    heightMap_ = engine_.createMappedTextureI();
+    heightMap_->setEmptyTexture(
+        Resolution,
+        Resolution,
+        Texture::TextureFormat::R32F,
+        backend::ImageUsage::Storage,
+        1,
+        1);
+
+    // map generation
+    displacementMap_ = engine_.createMappedTextureI();
+    displacementMap_->setEmptyTexture(
+        Resolution, Resolution, Texture::TextureFormat::RGBA32F, backend::ImageUsage::Storage, 1, 1);
+    gradientMap_ = engine_.createMappedTextureI();
+    gradientMap_->setEmptyTexture(
+        Resolution, Resolution, Texture::TextureFormat::RGBA32F, backend::ImageUsage::Storage, 1, 1);
+}
+
+IWaveGenerator::~IWaveGenerator() {}
+
+void IWaveGenerator::render(rg::RenderGraph& rGraph, IScene& scene, float dt, util::Timer<NanoSeconds>& timer)
+{
+    float N = static_cast<float>(Resolution);
+    float log2N = static_cast<float>(log2N_);
+
+    // only generate the initial spectrum data if something has changed - i.e wind speed or direction
+    if (updateSpectrum_)
+    {
+        rGraph.addExecutorPass("initial_spectrum", [=](vkapi::VkDriver& driver) {
+            auto& cmds = driver.getCommands();
+            auto& cmdBuffer = cmds.getCmdBuffer().cmdBuffer;
+
+            initialSpecCompute_->addStorageImage(
+                driver,
+                "NoiseImage",
+                noiseTexture_->getBackendHandle(),
+                0,
+                ImageStorageSet::StorageType::ReadOnly);
+
+            // the output textures - h0k and h0-k
+            initialSpecCompute_->addStorageImage(
+                driver,
+                "H0kImage",
+                h0kTexture_->getBackendHandle(),
+                1,
+                ImageStorageSet::StorageType::WriteOnly);
+            initialSpecCompute_->addStorageImage(
+                driver,
+                "H0minuskImage",
+                h0minuskTexture_->getBackendHandle(),
+                2,
+                ImageStorageSet::StorageType::WriteOnly);
+
+            initialSpecCompute_->addUboParam("N", backend::BufferElementType::Int, (void*)&Resolution);
+            initialSpecCompute_->addUboParam(
+                "windSpeed", backend::BufferElementType::Float, (void*)&options.windSpeed);
+            initialSpecCompute_->addUboParam(
+                "windDirection", backend::BufferElementType::Float2, (void*)&options.windDirection);
+            initialSpecCompute_->addUboParam(
+                "L", backend::BufferElementType::Int, (void*)&options.L);
+            initialSpecCompute_->addUboParam(
+                "A", backend::BufferElementType::Float, (void*)&options.A);
+
+            auto* bundle = initialSpecCompute_->build(engine_, "initial_spectrum.comp");
+            driver.dispatchCompute(
+                cmds.getCmdBuffer().cmdBuffer, bundle, Resolution / 16, Resolution / 16, 1);
+        });
+
+        // Note: the butterfly image only needs updating if user deinfed chnages in resolution are allowed
+        // at some point. This may need moving under its own flag.
+        rGraph.addExecutorPass("fft_butterfly", [=](vkapi::VkDriver& driver) {
+            auto& cmds = driver.getCommands();
+            auto& cmdBuffer = cmds.getCmdBuffer().cmdBuffer;
+
+            butterflyCompute_->addStorageImage(
+                driver,
+                "ButterflyImage",
+                butterflyLut_->getBackendHandle(),
+                0,
+                ImageStorageSet::StorageType::WriteOnly);
+
+            butterflyCompute_->addSsbo(
+                "bitReversed",
+                backend::BufferElementType::Uint,
+                StorageBuffer::AccessType::ReadWrite,
+                0,
+                "ssbo",
+                reversedBits_,
+                Resolution);
+
+            butterflyCompute_->addUboParam("N", backend::BufferElementType::Float, (void*)&N);
+            butterflyCompute_->addUboParam(
+                "log2N", backend::BufferElementType::Float, (void*)&log2N);
+
+            auto* bundle = butterflyCompute_->build(engine_, "fft_butterfly.comp");
+            driver.dispatchCompute(
+                cmds.getCmdBuffer().cmdBuffer, bundle, log2N_, Resolution / 16, 1);
+        });
+
+        updateSpectrum_ = false;
+    }
+
+     rGraph.addExecutorPass("spectrum", [=](vkapi::VkDriver& driver) {
+        auto& cmds = driver.getCommands();
+        auto& cmdBuffer = cmds.getCmdBuffer().cmdBuffer;
+
+        // input images from the initial spectrum compute call
+        specCompute_->addStorageImage(
+            driver,
+            "H0kImage",
+            h0kTexture_->getBackendHandle(),
+            0,
+            ImageStorageSet::StorageType::ReadOnly);
+        specCompute_->addStorageImage(
+            driver,
+            "H0minuskImage",
+            h0minuskTexture_->getBackendHandle(),
+            1,
+            ImageStorageSet::StorageType::ReadOnly);
+
+        // output images - dxyz
+        specCompute_->addSsbo(
+            "out_dxyz",
+            backend::BufferElementType::Float2,
+            StorageBuffer::AccessType::ReadWrite,
+            0,
+            "ssbo",
+            nullptr,
+            dxyzBufferSize);
+
+        specCompute_->addUboParam("N", backend::BufferElementType::Int, (void*)&Resolution);
+        specCompute_->addUboParam("L", backend::BufferElementType::Int, (void*)&options.L);
+        specCompute_->addUboParam("time", backend::BufferElementType::Float, (void*)&dt);
+        specCompute_->addUboParam("offset_dx", backend::BufferElementType::Int, (void*)&dxOffset);
+        specCompute_->addUboParam("offset_dy", backend::BufferElementType::Int, (void*)&dyOffset);
+        specCompute_->addUboParam("offset_dz", backend::BufferElementType::Int, (void*)&dzOffset);
+
+        auto* bundle = specCompute_->build(engine_, "fft_spectrum.comp");
+
+        vkapi::VkContext::writeReadComputeBarrier(cmdBuffer);
+        driver.dispatchCompute(
+            cmds.getCmdBuffer().cmdBuffer, bundle, Resolution / 16, Resolution / 16, 1);
+    });
+
+    rGraph.addExecutorPass("fft", [=](vkapi::VkDriver& driver) {
+        auto& cmds = driver.getCommands();
+        auto& cmdBuffer = cmds.getCmdBuffer().cmdBuffer;
+
+        // setup horizontal fft
+        fftHorizCompute_->addStorageImage(
+            driver,
+            "ButterflySampler",
+            butterflyLut_->getBackendHandle(),
+            0,
+            ImageStorageSet::StorageType::ReadOnly);
+
+        fftHorizCompute_->addSsbo(
+            "pingpong0",
+            backend::BufferElementType::Float2,
+            StorageBuffer::AccessType::ReadWrite,
+            0,
+            "ssbo_a",
+            nullptr,
+            dxyzBufferSize);
+
+        fftHorizCompute_->copySsbo(
+            *specCompute_, 0, 1, StorageBuffer::AccessType::ReadWrite, "SsboBufferB", "ssbo_b");
+
+        fftHorizCompute_->addUboParam("N", backend::BufferElementType::Float, (void*)&N);
+        fftHorizCompute_->addPushConstantParam("stage", backend::BufferElementType::Int);
+        fftHorizCompute_->addPushConstantParam("pingpong", backend::BufferElementType::Int);
+        fftHorizCompute_->addPushConstantParam("offset", backend::BufferElementType::Uint);
+
+        auto* horizBundle = fftHorizCompute_->build(engine_, "fft_horiz.comp");
+
+        // setup vertical fft
+        fftVertCompute_->addStorageImage(
+            driver,
+            "ButterflySampler",
+            butterflyLut_->getBackendHandle(),
+            0,
+            ImageStorageSet::StorageType::ReadOnly);
+
+        fftVertCompute_->copySsbo(
+            *fftHorizCompute_,
+            0,
+            0,
+            StorageBuffer::AccessType::ReadWrite,
+            "SsboBufferA",
+            "ssbo_a");
+           
+        fftVertCompute_->copySsbo(
+            *fftHorizCompute_,
+            1,
+            1,
+            StorageBuffer::AccessType::ReadWrite,
+            "SsboBufferB",
+            "ssbo_b");
+
+        fftVertCompute_->addUboParam("N", backend::BufferElementType::Float, (void*)&N);
+        fftVertCompute_->addPushConstantParam("stage", backend::BufferElementType::Int);
+        fftVertCompute_->addPushConstantParam("pingpong", backend::BufferElementType::Int);
+        fftVertCompute_->addPushConstantParam("offset", backend::BufferElementType::Uint);
+
+        auto* vertBundle = fftVertCompute_->build(engine_, "fft_vert.comp");
+        vkapi::VkContext::writeReadComputeBarrier(cmdBuffer);
+
+        // dispatch horizontal fft 
+        for (size_t n = 0; n < log2N_; ++n)
+        {
+            pingpong_ = pingpong_ == 0 ? 1 : 0;
+            fftHorizCompute_->updatePushConstantParam("stage", &n);
+            fftHorizCompute_->updatePushConstantParam("pingpong", &pingpong_);
+
+            // horizontal dx
+            fftHorizCompute_->updatePushConstantParam("offset", (void*)&dxOffset);
+            fftHorizCompute_->updateGpuPush();
+            driver.dispatchCompute(
+                cmds.getCmdBuffer().cmdBuffer, horizBundle, Resolution / 16, Resolution / 16, 1);
+
+            // horizontal dy
+            fftHorizCompute_->updatePushConstantParam("offset", (void*)&dyOffset);
+            fftHorizCompute_->updateGpuPush();
+            driver.dispatchCompute(
+                cmds.getCmdBuffer().cmdBuffer, horizBundle, Resolution / 16, Resolution / 16, 1);
+
+            // horizontal dz
+            fftHorizCompute_->updatePushConstantParam("offset", (void*)&dzOffset);
+            fftHorizCompute_->updateGpuPush();
+            driver.dispatchCompute(
+                cmds.getCmdBuffer().cmdBuffer, horizBundle, Resolution / 16, Resolution / 16, 1);
+        }
+
+        vkapi::VkContext::writeReadComputeBarrier(cmdBuffer);
+
+        // dispatch vertical fft 
+        for (size_t n = 0; n < log2N_; ++n)
+        {
+            pingpong_ = pingpong_ == 0 ? 1 : 0;
+            fftVertCompute_->updatePushConstantParam("stage", &n);
+            fftVertCompute_->updatePushConstantParam("pingpong", &pingpong_);
+
+            // vertical dx
+            fftVertCompute_->updatePushConstantParam("offset", (void*)&dxOffset);
+            fftVertCompute_->updateGpuPush();
+            driver.dispatchCompute(
+                cmds.getCmdBuffer().cmdBuffer, vertBundle, Resolution / 16, Resolution / 16, 1);
+
+            // vertical dy
+            fftVertCompute_->updatePushConstantParam("offset", (void*)&dyOffset);
+            fftVertCompute_->updateGpuPush();
+            driver.dispatchCompute(
+                cmds.getCmdBuffer().cmdBuffer, vertBundle, Resolution / 16, Resolution / 16, 1);
+
+            // vertical dz
+            fftVertCompute_->updatePushConstantParam("offset", (void*)&dzOffset);
+            fftVertCompute_->updateGpuPush();
+            driver.dispatchCompute(
+                cmds.getCmdBuffer().cmdBuffer, vertBundle, Resolution / 16, Resolution / 16, 1);
+        }
+    });
+
+    rGraph.addExecutorPass("displacement", [=](vkapi::VkDriver& driver) {
+        auto& cmds = driver.getCommands();
+        auto& cmdBuffer = cmds.getCmdBuffer().cmdBuffer;
+
+        if (pingpong_)
+        {
+            displaceCompute_->copySsbo(
+                *fftVertCompute_,
+                0,
+                0,
+                StorageBuffer::AccessType::ReadWrite,
+                "SsboBufferA",
+                "ssbo");
+        }
+        else
+        {
+            displaceCompute_->copySsbo(
+                *fftVertCompute_,
+                1,
+                1,
+                StorageBuffer::AccessType::ReadWrite,
+                "SsboBufferA",
+                "ssbo");
+        }
+
+        displaceCompute_->addStorageImage(
+            driver,
+            "DisplacementMap",
+            fftOutputImage_->getBackendHandle(),
+            0,
+            ImageStorageSet::StorageType::WriteOnly);
+        displaceCompute_->addStorageImage(
+            driver,
+            "HeightMap",
+            heightMap_->getBackendHandle(),
+            1,
+            ImageStorageSet::StorageType::WriteOnly);
+
+       displaceCompute_->addUboParam("N", backend::BufferElementType::Float, (void*)&N); 
+       displaceCompute_->addUboParam("choppyFactor", backend::BufferElementType::Float, (void*)&options.choppyFactor);
+       displaceCompute_->addUboParam("offset_dx", backend::BufferElementType::Int, (void*)&dxOffset);
+       displaceCompute_->addUboParam("offset_dy", backend::BufferElementType::Int, (void*)&dyOffset);
+       displaceCompute_->addUboParam("offset_dz", backend::BufferElementType::Int, (void*)&dzOffset);
+       
+       auto* bundle = displaceCompute_->build(engine_, "fft_displacement.comp");
+
+       vkapi::VkContext::writeReadComputeBarrier(cmdBuffer);
+       driver.dispatchCompute(cmds.getCmdBuffer().cmdBuffer, bundle, Resolution / 16, Resolution / 16, 1);
+
+     });
+
+     rGraph.addExecutorPass("generate_maps", [=](vkapi::VkDriver& driver) {
+        auto& cmds = driver.getCommands();
+        auto& cmdBuffer = cmds.getCmdBuffer().cmdBuffer;
+
+        // input samplers
+        genMapCompute_->addImageSampler(
+            driver,
+            "fftOutputImage",
+            fftOutputImage_->getBackendHandle(),
+            0,
+            {backend::SamplerFilter::Nearest});
+        genMapCompute_->addImageSampler(
+            driver,
+            "HeightMap",
+            heightMap_->getBackendHandle(),
+            1,
+            {backend::SamplerFilter::Nearest});
+
+        // output storage images
+        genMapCompute_->addStorageImage(
+            driver,
+            "DisplacementMap",
+            displacementMap_->getBackendHandle(),
+            2,
+            ImageStorageSet::StorageType::WriteOnly);
+        genMapCompute_->addStorageImage(
+            driver,
+            "GradientMap",
+            gradientMap_->getBackendHandle(),
+            3,
+            ImageStorageSet::StorageType::WriteOnly);
+
+        genMapCompute_->addUboParam("N", backend::BufferElementType::Float, (void*)&N);
+        genMapCompute_->addUboParam(
+            "choppyFactor", backend::BufferElementType::Float, (void*)&options.choppyFactor);
+        genMapCompute_->addUboParam(
+            "gridLength", backend::BufferElementType::Float, (void*)&options.gridLength);
+
+        auto* bundle = genMapCompute_->build(engine_, "generate_maps.comp");
+
+        vkapi::VkContext::writeReadComputeBarrier(cmdBuffer);
+        driver.dispatchCompute(
+            cmds.getCmdBuffer().cmdBuffer, bundle, Resolution / 16, Resolution / 16, 1);
+
+        cmds.flush();
+    });
+}
+
+// ============================ client api =================================
+
+WaveGenerator::WaveGenerator() = default;
+WaveGenerator::~WaveGenerator() = default;
+
+}

--- a/yave/src/wave_generator.h
+++ b/yave/src/wave_generator.h
@@ -1,0 +1,117 @@
+/* Copyright (c) 2022 Garry Whitehead
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#pragma once
+#include "yave/wave_generator.h"
+#include "render_graph/render_graph.h"
+
+#include <utility/timer.h>
+
+#include <mathfu/glsl_mappings.h>
+
+#include <cstdint>
+
+namespace yave
+{
+class IEngine;
+class IScene;
+class Compute;
+class IMappedTexture;
+
+class IWaveGenerator : public WaveGenerator
+{
+public:
+
+	// fixed resolution, maybe user defined at some point?
+	static constexpr int Resolution = 256;
+    // dxyz buffer offsets
+    static constexpr int dxOffset = 0;
+    static constexpr int dyOffset = Resolution * Resolution;
+    static constexpr int dzOffset = dyOffset * 2;
+    static constexpr int dxyzBufferSize = Resolution * Resolution * 3;
+	
+	// temp measure - move to scene!
+	struct WaveOptions
+    {
+		int L = 1000;
+        float A = 4.0f;
+        mathfu::vec2 windDirection {4.0f, 2.0f};
+        float windSpeed = 40.0f;
+        float choppyFactor = 1.0f;
+        float gridLength = 1024.0f;
+	};
+
+	IWaveGenerator(IEngine& engine);
+    ~IWaveGenerator();
+
+	void render(rg::RenderGraph& rGraph, IScene& scene, float dt, util::Timer<NanoSeconds>& timer);
+
+private:
+
+	IEngine& engine_;
+
+	size_t log2N_;
+    uint32_t reversedBits_[Resolution];
+    // 4 channels for our noise texture
+    float noiseMap_[Resolution * Resolution * 4];
+
+	// inital spectrum compute
+	// output textures
+    IMappedTexture* h0kTexture_;
+    IMappedTexture* h0minuskTexture_;
+
+    std::unique_ptr<Compute> initialSpecCompute_;
+    IMappedTexture* noiseTexture_;
+	 
+	// spectrum
+    IMappedTexture* dztTexture_;
+    IMappedTexture* dytTexture_;
+    IMappedTexture* dxtTexture_;
+    std::unique_ptr<Compute> specCompute_;
+	
+	// fft butterfly compute
+	IMappedTexture* butterflyLut_;
+    std::unique_ptr<Compute> butterflyCompute_;
+
+	// fft compute
+    std::unique_ptr<Compute> fftHorizCompute_;
+    std::unique_ptr<Compute> fftVertCompute_;
+    IMappedTexture* pingpongTexture_;
+
+	// displacement
+    IMappedTexture* fftOutputImage_;
+    IMappedTexture* heightMap_;
+    std::unique_ptr<Compute> displaceCompute_;
+
+    // map generation
+    IMappedTexture* gradientMap_;
+    // height and displacement
+    IMappedTexture* displacementMap_;
+    std::unique_ptr<Compute> genMapCompute_;
+
+	int pingpong_;
+
+	WaveOptions options;
+
+	bool updateSpectrum_;
+};
+}

--- a/yave/src/wave_generator.h
+++ b/yave/src/wave_generator.h
@@ -21,12 +21,11 @@
  */
 
 #pragma once
-#include "yave/wave_generator.h"
 #include "render_graph/render_graph.h"
-
-#include <utility/timer.h>
+#include "yave/wave_generator.h"
 
 #include <mathfu/glsl_mappings.h>
+#include <utility/timer.h>
 
 #include <cstdint>
 
@@ -40,64 +39,62 @@ class IMappedTexture;
 class IWaveGenerator : public WaveGenerator
 {
 public:
-
-	// fixed resolution, maybe user defined at some point?
-	static constexpr int Resolution = 256;
+    // fixed resolution, maybe user defined at some point?
+    static constexpr int Resolution = 256;
     // dxyz buffer offsets
     static constexpr int dxOffset = 0;
     static constexpr int dyOffset = Resolution * Resolution;
     static constexpr int dzOffset = dyOffset * 2;
     static constexpr int dxyzBufferSize = Resolution * Resolution * 3;
-	
-	// temp measure - move to scene!
-	struct WaveOptions
+
+    // temp measure - move to scene!
+    struct WaveOptions
     {
-		int L = 1000;
+        int L = 1000;
         float A = 4.0f;
         mathfu::vec2 windDirection {4.0f, 2.0f};
         float windSpeed = 40.0f;
         float choppyFactor = 1.0f;
         float gridLength = 1024.0f;
-	};
+    };
 
-	IWaveGenerator(IEngine& engine);
+    IWaveGenerator(IEngine& engine);
     ~IWaveGenerator();
 
-	void render(rg::RenderGraph& rGraph, IScene& scene, float dt, util::Timer<NanoSeconds>& timer);
+    void render(rg::RenderGraph& rGraph, IScene& scene, float dt, util::Timer<NanoSeconds>& timer);
 
 private:
+    IEngine& engine_;
 
-	IEngine& engine_;
-
-	size_t log2N_;
+    size_t log2N_;
     uint32_t reversedBits_[Resolution];
     // 4 channels for our noise texture
     float noiseMap_[Resolution * Resolution * 4];
 
-	// inital spectrum compute
-	// output textures
+    // inital spectrum compute
+    // output textures
     IMappedTexture* h0kTexture_;
     IMappedTexture* h0minuskTexture_;
 
     std::unique_ptr<Compute> initialSpecCompute_;
     IMappedTexture* noiseTexture_;
-	 
-	// spectrum
+
+    // spectrum
     IMappedTexture* dztTexture_;
     IMappedTexture* dytTexture_;
     IMappedTexture* dxtTexture_;
     std::unique_ptr<Compute> specCompute_;
-	
-	// fft butterfly compute
-	IMappedTexture* butterflyLut_;
+
+    // fft butterfly compute
+    IMappedTexture* butterflyLut_;
     std::unique_ptr<Compute> butterflyCompute_;
 
-	// fft compute
+    // fft compute
     std::unique_ptr<Compute> fftHorizCompute_;
     std::unique_ptr<Compute> fftVertCompute_;
     IMappedTexture* pingpongTexture_;
 
-	// displacement
+    // displacement
     IMappedTexture* fftOutputImage_;
     IMappedTexture* heightMap_;
     std::unique_ptr<Compute> displaceCompute_;
@@ -108,10 +105,10 @@ private:
     IMappedTexture* displacementMap_;
     std::unique_ptr<Compute> genMapCompute_;
 
-	int pingpong_;
+    int pingpong_;
 
-	WaveOptions options;
+    WaveOptions options;
 
-	bool updateSpectrum_;
+    bool updateSpectrum_;
 };
-}
+} // namespace yave


### PR DESCRIPTION
Adds the following:

- compute shaders for generating height and gradient maps - uses a gaussain random distribution noise image to define the initial complex values which are used to generate the h0k values via the Phillips spectrum. This in turn computes the h(k,t) time independent part which is fed into the 2d FFT to create the frequency spectrum -> height, displacement; 
- Initial wave generator API - very basic at present.
- Chnages to `Compute` to add the missing functionality required for the above - samplers, image storage are now both supported.